### PR TITLE
PTY Signal Overhaul

### DIFF
--- a/abi/src/signal.rs
+++ b/abi/src/signal.rs
@@ -142,11 +142,14 @@ pub const fn sig_default_action(signum: u8) -> SigDefault {
 
 /// Signal frame pushed onto the user stack when delivering a signal.
 /// rt_sigreturn restores execution state from this frame.
+///
+/// The restorer address is NOT part of this frame — it is pushed as a
+/// separate 8-byte word on the stack before the frame (Linux convention).
+/// When the handler does `ret`, it pops the restorer into RIP, and RSP
+/// then points to this SignalFrame, which rt_sigreturn reads directly.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct SignalFrame {
-    /// Restorer return address (pushed as the "return address" for the handler).
-    pub restorer: u64,
     /// Signal number being delivered.
     pub signum: u64,
     /// Saved general-purpose registers.

--- a/abi/src/syscall/numbers.rs
+++ b/abi/src/syscall/numbers.rs
@@ -61,6 +61,8 @@ pub const SYSCALL_TTY_SET_FOCUS: u64 = 28;
 pub const SYSCALL_OPENPTY: u64 = 145;
 pub const SYSCALL_TTY_READ: u64 = 146;
 pub const SYSCALL_TTY_WRITE: u64 = 147;
+/// Open a file descriptor for a TTY by its index.  Returns the new fd number.
+pub const SYSCALL_OPEN_TTY_FD: u64 = 148;
 pub const SYSCALL_GET_TIME_MS: u64 = 39;
 pub const SYSCALL_REBOOT: u64 = 85;
 
@@ -649,7 +651,7 @@ pub const FONT_FORMAT_BITMAP: u64 = 0;
 pub const FONT_FORMAT_COVERAGE: u64 = 1;
 
 // Syscall numbers 145-147 are reserved for future font/console operations.
-pub const SYSCALL_TABLE_SIZE: usize = 148;
+pub const SYSCALL_TABLE_SIZE: usize = 149;
 
 /// Standard return value for unimplemented syscalls: -ENOSYS (negated errno 38).
 pub const ENOSYS_RETURN: u64 = (-38i64) as u64;

--- a/abi/src/syscall/numbers.rs
+++ b/abi/src/syscall/numbers.rs
@@ -650,7 +650,7 @@ pub const FONT_FORMAT_BITMAP: u64 = 0;
 /// Pre-rasterized coverage format: 8-bit-per-pixel alpha, 95 glyphs + replacement.
 pub const FONT_FORMAT_COVERAGE: u64 = 1;
 
-// Syscall numbers 145-147 are reserved for future font/console operations.
+// Syscall numbers 145-148 are in active use (OPENPTY, TTY_READ, TTY_WRITE, OPEN_TTY_FD).
 pub const SYSCALL_TABLE_SIZE: usize = 149;
 
 /// Standard return value for unimplemented syscalls: -ENOSYS (negated errno 38).

--- a/core/src/scheduler/per_cpu.rs
+++ b/core/src/scheduler/per_cpu.rs
@@ -299,6 +299,7 @@ impl PerCpuScheduler {
         self.schedule_calls.store(0, Ordering::Relaxed);
         self.initialized.store(true, Ordering::Release);
         self.clear_remote_inbox_with_ref_release();
+        self.inbox_count.store(0, Ordering::Relaxed);
     }
 
     pub fn is_initialized(&self) -> bool {
@@ -394,6 +395,14 @@ impl PerCpuScheduler {
         } else {
             load
         }
+    }
+
+    /// Reset inbox_count to zero.  For test fixtures only — clears stale
+    /// counts that leak between test runs due to SMP timing.
+    #[cfg(feature = "itests")]
+    pub fn force_clear_inbox_count(&self) {
+        self.clear_remote_inbox_with_ref_release();
+        self.inbox_count.store(0, Ordering::Relaxed);
     }
 
     pub fn steal_task(&self) -> Option<*mut Task> {

--- a/core/src/scheduler/sched_tests.rs
+++ b/core/src/scheduler/sched_tests.rs
@@ -65,10 +65,14 @@ impl SchedFixture {
         // the previous fixture's drop and this init (e.g. from AP timer
         // ticks that fired before pause took effect).
         for cpu in 0..slopos_arch::pcr::get_cpu_count() {
-            super::per_cpu::with_cpu_scheduler(cpu, |sched| {
+            if super::per_cpu::with_cpu_scheduler(cpu, |sched| {
                 sched.force_clear_inbox_count();
             })
-            .expect("SCHED_TEST: CPU scheduler missing after init");
+            .is_none()
+            {
+                resume_all_aps_if_not_nested(aps_paused);
+                panic!("SCHED_TEST: CPU scheduler missing after init");
+            }
         }
 
         Self { aps_paused }

--- a/core/src/scheduler/sched_tests.rs
+++ b/core/src/scheduler/sched_tests.rs
@@ -67,7 +67,8 @@ impl SchedFixture {
         for cpu in 0..slopos_arch::pcr::get_cpu_count() {
             super::per_cpu::with_cpu_scheduler(cpu, |sched| {
                 sched.force_clear_inbox_count();
-            });
+            })
+            .expect("SCHED_TEST: CPU scheduler missing after init");
         }
 
         Self { aps_paused }

--- a/core/src/scheduler/sched_tests.rs
+++ b/core/src/scheduler/sched_tests.rs
@@ -53,10 +53,12 @@ impl SchedFixture {
         if init_task_manager() != 0 {
             klog_info!("SCHED_TEST: Failed to init task manager");
             resume_all_aps_if_not_nested(aps_paused);
+            panic!("SCHED_TEST: init_task_manager failed");
         }
         if init_scheduler() != 0 {
             klog_info!("SCHED_TEST: Failed to init scheduler");
             resume_all_aps_if_not_nested(aps_paused);
+            panic!("SCHED_TEST: init_scheduler failed");
         }
 
         // Force-clear any stale inbox counts that accumulated between

--- a/core/src/scheduler/sched_tests.rs
+++ b/core/src/scheduler/sched_tests.rs
@@ -53,12 +53,19 @@ impl SchedFixture {
         if init_task_manager() != 0 {
             klog_info!("SCHED_TEST: Failed to init task manager");
             resume_all_aps_if_not_nested(aps_paused);
-            // Continue anyway - tests will fail if needed
         }
         if init_scheduler() != 0 {
             klog_info!("SCHED_TEST: Failed to init scheduler");
             resume_all_aps_if_not_nested(aps_paused);
-            // Continue anyway - tests will fail if needed
+        }
+
+        // Force-clear any stale inbox counts that accumulated between
+        // the previous fixture's drop and this init (e.g. from AP timer
+        // ticks that fired before pause took effect).
+        for cpu in 0..slopos_arch::pcr::get_cpu_count() {
+            super::per_cpu::with_cpu_scheduler(cpu, |sched| {
+                sched.force_clear_inbox_count();
+            });
         }
 
         Self { aps_paused }
@@ -1864,12 +1871,10 @@ pub fn test_select_target_cpu_prefers_idle_cpu() -> TestResult {
         (*task_ptr).last_cpu = cpu_id as u8; // last ran on the busy CPU
     }
 
-    // select_target_cpu should see that cpu_id is loaded and pick other_cpu.
     let target = super::per_cpu::select_target_cpu(task_ptr);
     match target {
         Some(t) if t == other_cpu => { /* expected — migrated to idle CPU */ }
         Some(t) if t == cpu_id => {
-            // This is the old buggy behaviour — always returning last_cpu.
             klog_info!(
                 "SCHED_TEST: select_target_cpu returned busy last_cpu {} instead of idle CPU {}",
                 cpu_id,

--- a/core/src/syscall/fs/poll_ioctl_handlers.rs
+++ b/core/src/syscall/fs/poll_ioctl_handlers.rs
@@ -460,8 +460,7 @@ define_syscall!(syscall_ioctl(ctx, args) requires(let task_id, let pid: process_
                 Ok(idx) => idx,
                 Err(_) => return ctx.err(),
             };
-            let open_flags = arg as u32;
-            let new_fd = file_open_tty_fd(pid, peer_tty, open_flags);
+            let new_fd = file_open_tty_fd(pid, peer_tty);
             if new_fd < 0 {
                 let _ = tty::close_ref(peer_tty);
                 ctx.err()

--- a/core/src/syscall/fs/poll_ioctl_handlers.rs
+++ b/core/src/syscall/fs/poll_ioctl_handlers.rs
@@ -460,7 +460,7 @@ define_syscall!(syscall_ioctl(ctx, args) requires(let task_id, let pid: process_
                 Ok(idx) => idx,
                 Err(_) => return ctx.err(),
             };
-            let new_fd = file_open_tty_fd(pid, peer_tty);
+            let new_fd = file_open_tty_fd(pid, peer_tty, arg as u32);
             if new_fd < 0 {
                 let _ = tty::close_ref(peer_tty);
                 ctx.err()

--- a/core/src/syscall/handlers.rs
+++ b/core/src/syscall/handlers.rs
@@ -39,15 +39,15 @@ pub use crate::syscall::ui_handlers::{
     syscall_enumerate_windows, syscall_fb_flip, syscall_fb_info, syscall_input_get_button_state,
     syscall_input_get_pointer_pos, syscall_input_has_events, syscall_input_poll,
     syscall_input_poll_batch, syscall_input_request_close, syscall_input_set_focus,
-    syscall_input_set_focus_with_offset, syscall_mark_frames_done, syscall_openpty,
-    syscall_poll_frame_done, syscall_raise_window, syscall_random_next, syscall_roulette_draw,
-    syscall_roulette_result, syscall_roulette_spin, syscall_set_cursor_shape,
-    syscall_set_window_position, syscall_set_window_state, syscall_shm_acquire, syscall_shm_create,
-    syscall_shm_create_with_format, syscall_shm_destroy, syscall_shm_get_formats, syscall_shm_map,
-    syscall_shm_poll_released, syscall_shm_release, syscall_shm_unmap, syscall_surface_attach,
-    syscall_surface_commit, syscall_surface_damage, syscall_surface_frame,
-    syscall_surface_set_parent, syscall_surface_set_rel_pos, syscall_surface_set_role,
-    syscall_surface_set_title, syscall_tty_read, syscall_tty_write,
+    syscall_input_set_focus_with_offset, syscall_mark_frames_done, syscall_open_tty_fd,
+    syscall_openpty, syscall_poll_frame_done, syscall_raise_window, syscall_random_next,
+    syscall_roulette_draw, syscall_roulette_result, syscall_roulette_spin,
+    syscall_set_cursor_shape, syscall_set_window_position, syscall_set_window_state,
+    syscall_shm_acquire, syscall_shm_create, syscall_shm_create_with_format, syscall_shm_destroy,
+    syscall_shm_get_formats, syscall_shm_map, syscall_shm_poll_released, syscall_shm_release,
+    syscall_shm_unmap, syscall_surface_attach, syscall_surface_commit, syscall_surface_damage,
+    syscall_surface_frame, syscall_surface_set_parent, syscall_surface_set_rel_pos,
+    syscall_surface_set_role, syscall_surface_set_title, syscall_tty_read, syscall_tty_write,
 };
 
 /// Build the static syscall dispatch table from a compact registration list.
@@ -127,6 +127,7 @@ static SYSCALL_TABLE: [SyscallEntry; SYSCALL_TABLE_SIZE] = syscall_table! {
     [SYSCALL_OPENPTY]       => syscall_openpty,       "openpty";
     [SYSCALL_TTY_READ]      => syscall_tty_read,      "tty_read";
     [SYSCALL_TTY_WRITE]     => syscall_tty_write,     "tty_write";
+    [SYSCALL_OPEN_TTY_FD]   => syscall_open_tty_fd,   "open_tty_fd";
 
     // Window management
     [SYSCALL_ENUMERATE_WINDOWS]   => syscall_enumerate_windows,   "enumerate_windows";

--- a/core/src/syscall/signal.rs
+++ b/core/src/syscall/signal.rs
@@ -352,8 +352,10 @@ pub fn syscall_rt_sigreturn(task: *mut Task, frame: *mut InterruptFrame) -> Sysc
         None => return ctx.err_with(ERRNO_EINVAL),
     };
 
+    // After the handler's `ret` pops the restorer address, RSP points
+    // directly at the SignalFrame.  Read it from there.
     let rsp = unsafe { (*frame).rsp };
-    let sigframe = match read_signal_frame(rsp).or_else(|| read_signal_frame(rsp.wrapping_sub(8))) {
+    let sigframe = match read_signal_frame(rsp) {
         Some(sf) => sf,
         None => return ctx.err_with(ERRNO_EFAULT),
     };
@@ -430,18 +432,35 @@ pub fn deliver_pending_signal(task: *mut Task, frame: *mut InterruptFrame) {
             return;
         }
 
-        let frame_addr = ((*frame)
-            .rsp
-            .wrapping_sub(core::mem::size_of::<SignalFrame>() as u64))
-            & !0xF;
-        let sigframe_ptr = match UserPtr::<SignalFrame>::try_new(frame_addr) {
+        // Linux convention: push the restorer address as a separate word
+        // on the stack BEFORE the SignalFrame.  When the handler does
+        // `ret`, it pops the restorer into RIP and RSP advances to point
+        // at the SignalFrame, which rt_sigreturn reads directly.
+        //
+        // Stack layout (low address → high address):
+        //   [frame_addr + 0]  = restorer address   (popped by `ret`)
+        //   [frame_addr + 8]  = SignalFrame { signum, rax, … }
+        let total_size = 8 + core::mem::size_of::<SignalFrame>() as u64;
+        let frame_addr = (*frame).rsp.wrapping_sub(total_size) & !0xF;
+
+        // Write restorer as a separate u64 at frame_addr.
+        let restorer_ptr = match UserPtr::<u64>::try_new(frame_addr) {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        if copy_to_user(restorer_ptr, &action.restorer).is_err() {
+            return;
+        }
+
+        // Write SignalFrame at frame_addr + 8.
+        let sigframe_addr = frame_addr.wrapping_add(8);
+        let sigframe_ptr = match UserPtr::<SignalFrame>::try_new(sigframe_addr) {
             Ok(p) => p,
             Err(_) => return,
         };
 
         let saved_mask = (*task).signal_blocked;
         let sigframe = SignalFrame {
-            restorer: action.restorer,
             signum: signum as u64,
             rax: (*frame).rax,
             rbx: (*frame).rbx,

--- a/core/src/syscall/tests.rs
+++ b/core/src/syscall/tests.rs
@@ -1543,7 +1543,23 @@ pub fn test_signal_install_deliver_and_sigreturn() -> TestResult {
         "signal number not passed in RDI"
     );
 
-    let sigframe: SignalFrame = match user_copy_in(pid, user_frame.rsp) {
+    // The restorer address is pushed as a separate u64 at [rsp].
+    // The SignalFrame starts at [rsp + 8].
+    let restorer_on_stack: u64 = match user_copy_in(pid, user_frame.rsp) {
+        Some(v) => v,
+        None => {
+            task_terminate(task_id);
+            return TestResult::Fail;
+        }
+    };
+    assert_eq_test!(
+        restorer_on_stack,
+        new_action.sa_restorer,
+        "signal restorer mismatch"
+    );
+
+    let sigframe_addr = user_frame.rsp.wrapping_add(8);
+    let sigframe: SignalFrame = match user_copy_in(pid, sigframe_addr) {
         Some(v) => v,
         None => {
             task_terminate(task_id);
@@ -1560,12 +1576,10 @@ pub fn test_signal_install_deliver_and_sigreturn() -> TestResult {
         original_rsp,
         "saved RSP mismatch in signal frame"
     );
-    assert_eq_test!(
-        sigframe.restorer,
-        new_action.sa_restorer,
-        "signal restorer mismatch"
-    );
 
+    // Simulate handler's `ret`: it pops the restorer, advancing RSP by 8
+    // so it now points at the SignalFrame — matching the real flow.
+    user_frame.rsp = user_frame.rsp.wrapping_add(8);
     let _ = with_user_process_context(pid, || syscall_rt_sigreturn(task_ptr, &mut user_frame));
     assert_eq_test!(
         user_frame.rip,

--- a/core/src/syscall/ui_handlers.rs
+++ b/core/src/syscall/ui_handlers.rs
@@ -352,7 +352,7 @@ define_syscall!(syscall_open_tty_fd(ctx, args) requires(let pid: process_id) {
     if tty::open_ref(tty_idx).is_err() {
         return ctx.err();
     }
-    let fd = file_open_tty_fd(pid, tty_idx);
+    let fd = file_open_tty_fd(pid, tty_idx, 0);
     if fd < 0 {
         let _ = tty::close_ref(tty_idx);
         ctx.ok_i64(fd as i64)

--- a/core/src/syscall/ui_handlers.rs
+++ b/core/src/syscall/ui_handlers.rs
@@ -6,6 +6,7 @@ use slopos_abi::task::INVALID_TASK_ID;
 use slopos_abi::{DisplayInfo, InputEvent, WindowInfo};
 
 use crate::fate_api::{fate_apply_outcome, fate_set_pending, fate_spin, fate_take_pending};
+use slopos_fs::fileio::file_open_tty_fd;
 use slopos_kernel_services::platform;
 use slopos_kernel_services::syscall_services::{input, tty, video};
 
@@ -341,6 +342,22 @@ define_syscall!(syscall_tty_write(ctx, args) {
                 ctx.ok_i64(errno)
             }
         }
+    }
+});
+
+// Open a file descriptor pointing to a TTY by its kernel index.
+// Increments the TTY's open_count first (matching the VFS open path).
+define_syscall!(syscall_open_tty_fd(ctx, args) requires(let pid: process_id) {
+    let tty_idx = TtyIndex(args.arg0 as u8);
+    if tty::open_ref(tty_idx).is_err() {
+        return ctx.err();
+    }
+    let fd = file_open_tty_fd(pid, tty_idx);
+    if fd < 0 {
+        let _ = tty::close_ref(tty_idx);
+        ctx.ok_i64(fd as i64)
+    } else {
+        ctx.ok(fd as u64)
     }
 });
 

--- a/fs/src/fileio/fdops.rs
+++ b/fs/src/fileio/fdops.rs
@@ -45,7 +45,7 @@ fn install_fd_entry(
     process_id: u32,
     ops: &'static dyn FileOps,
     handle: usize,
-    mut flags: u32,
+    mut flags: OpenMode,
     call_tty_policy: Option<TtyIndex>,
 ) -> c_int {
     with_tables(|kernel, processes, open_files, _| {
@@ -62,7 +62,7 @@ fn install_fd_entry(
         };
 
         let mut position = 0u64;
-        if (flags & FILE_OPEN_APPEND) != 0 {
+        if flags.contains(OpenMode::APPEND) {
             if let Some(size) = ops.size(handle) {
                 position = size;
             } else {
@@ -80,24 +80,24 @@ fn install_fd_entry(
         };
 
         if ops.kind() == FileKind::Socket {
-            let mode_bits = flags & (FILE_OPEN_READ | FILE_OPEN_WRITE);
+            let mode_bits = flags & (OpenMode::READ | OpenMode::WRITE);
             flags = mode_bits;
             if let Some(open_file) = get_open_file_mut(open_files, open_file_idx) {
                 open_file.status_flags = flags;
-                let _ = ops.set_status_flags(handle, flags);
+                let _ = ops.set_status_flags(handle, flags.bits());
             }
         }
 
         table.descriptors[slot_idx] = FdEntry {
             open_file_idx,
-            cloexec: (flags & O_CLOEXEC as u32) != 0,
+            cloexec: (flags.bits() & O_CLOEXEC as u32) != 0,
             valid: true,
         };
 
         drop(guard);
 
         if let Some(tty_idx) = call_tty_policy {
-            maybe_acquire_controlling_tty_on_open(tty_idx, flags);
+            maybe_acquire_controlling_tty_on_open(tty_idx, flags.bits());
         }
 
         slot_idx as c_int
@@ -113,14 +113,14 @@ fn current_socket_ops() -> Option<&'static dyn FileOps> {
 }
 
 pub fn file_open_for_process(process_id: u32, path: *const c_char, posix_flags: u32) -> c_int {
-    let flags = posix_to_internal_flags(posix_flags);
+    let flags = posix_to_open_mode(posix_flags);
     if path.is_null() {
         return Errno::EFAULT.raw() as _;
     }
-    if (flags & (FILE_OPEN_READ | FILE_OPEN_WRITE)) == 0 {
+    if !flags.intersects(OpenMode::READ | OpenMode::WRITE) {
         return Errno::EINVAL.raw() as _;
     }
-    if (flags & FILE_OPEN_APPEND) != 0 && (flags & FILE_OPEN_WRITE) == 0 {
+    if flags.contains(OpenMode::APPEND) && !flags.contains(OpenMode::WRITE) {
         return Errno::EINVAL.raw() as _;
     }
 
@@ -154,7 +154,7 @@ pub fn file_open_for_process(process_id: u32, path: *const c_char, posix_flags: 
             process_id,
             tty_ops,
             master_idx.0 as usize,
-            flags | O_NOCTTY as u32,
+            flags.with_raw(O_NOCTTY as u32),
             None,
         );
     }
@@ -173,10 +173,10 @@ pub fn file_open_for_process(process_id: u32, path: *const c_char, posix_flags: 
         );
     }
 
-    let create = (flags & FILE_OPEN_CREAT) != 0;
+    let create = flags.contains(OpenMode::CREAT);
     let exclusive = (posix_flags & slopos_abi::fs::O_EXCL) != 0;
     let truncate = (posix_flags & slopos_abi::fs::O_TRUNC) != 0;
-    let writable = (flags & FILE_OPEN_WRITE) != 0;
+    let writable = flags.contains(OpenMode::WRITE);
     let open_flags = crate::vfs::ops::VfsOpenFlags {
         create,
         exclusive,
@@ -202,7 +202,7 @@ pub fn file_read_fd(process_id: u32, fd: c_int, buf: &mut dyn IoBufWrite) -> ssi
             let fd_entry = unsafe { get_fd_entry(&mut *table_ptr, fd) }?;
             let open_file_idx = fd_entry.open_file_idx;
             let open_file = get_open_file_mut(open_files, open_file_idx)?;
-            if (open_file.status_flags & FILE_OPEN_READ) == 0 {
+            if !open_file.status_flags.contains(OpenMode::READ) {
                 drop(guard);
                 return None;
             }
@@ -218,7 +218,14 @@ pub fn file_read_fd(process_id: u32, fd: c_int, buf: &mut dyn IoBufWrite) -> ssi
             drop(guard);
             Some(snapshot)
         })
-        .unwrap_or((u16::MAX, &VFS_FILE_OPS as &dyn FileOps, 0, 0, 0, false));
+        .unwrap_or((
+            u16::MAX,
+            &VFS_FILE_OPS as &dyn FileOps,
+            0,
+            OpenMode::EMPTY,
+            0,
+            false,
+        ));
 
     if open_file_idx == u16::MAX {
         return Errno::EBADF.raw() as _;
@@ -228,7 +235,7 @@ pub fn file_read_fd(process_id: u32, fd: c_int, buf: &mut dyn IoBufWrite) -> ssi
     }
 
     let used_offset = if seekable { offset } else { 0 };
-    let rc = ops.read(handle, buf, used_offset, flags);
+    let rc = ops.read(handle, buf, used_offset, flags.bits());
     if rc > 0 && seekable {
         with_tables(|_, _, open_files, _| {
             if let Some(open_file) = get_open_file_mut(open_files, open_file_idx)
@@ -253,7 +260,7 @@ pub fn file_write_fd(process_id: u32, fd: c_int, buf: &dyn IoBufRead) -> ssize_t
             let fd_entry = unsafe { get_fd_entry(&mut *table_ptr, fd) }?;
             let open_file_idx = fd_entry.open_file_idx;
             let open_file = get_open_file_mut(open_files, open_file_idx)?;
-            if (open_file.status_flags & FILE_OPEN_WRITE) == 0 {
+            if !open_file.status_flags.contains(OpenMode::WRITE) {
                 drop(guard);
                 return None;
             }
@@ -269,7 +276,14 @@ pub fn file_write_fd(process_id: u32, fd: c_int, buf: &dyn IoBufRead) -> ssize_t
             drop(guard);
             Some(snapshot)
         })
-        .unwrap_or((u16::MAX, &VFS_FILE_OPS as &dyn FileOps, 0, 0, 0, false));
+        .unwrap_or((
+            u16::MAX,
+            &VFS_FILE_OPS as &dyn FileOps,
+            0,
+            OpenMode::EMPTY,
+            0,
+            false,
+        ));
 
     if open_file_idx == u16::MAX {
         return Errno::EBADF.raw() as _;
@@ -279,7 +293,7 @@ pub fn file_write_fd(process_id: u32, fd: c_int, buf: &dyn IoBufRead) -> ssize_t
     }
 
     let used_offset = if seekable { offset } else { 0 };
-    let rc = ops.write(handle, buf, used_offset, flags);
+    let rc = ops.write(handle, buf, used_offset, flags.bits());
     if rc > 0 && seekable {
         with_tables(|_, _, open_files, _| {
             if let Some(open_file) = get_open_file_mut(open_files, open_file_idx)
@@ -531,13 +545,18 @@ pub fn file_get_tty_index(process_id: u32, fd: c_int) -> Option<TtyIndex> {
     })
 }
 
-pub fn file_open_tty_fd(process_id: u32, tty_idx: TtyIndex, flags: u32) -> c_int {
+/// Open a file descriptor for a TTY device.
+///
+/// TTY devices are inherently bidirectional, so READ and WRITE are always
+/// granted.  There is no `flags` parameter — callers cannot accidentally
+/// pass unconverted POSIX flags (the bug that `OpenMode` prevents).
+pub fn file_open_tty_fd(process_id: u32, tty_idx: TtyIndex) -> c_int {
     let tty_ops = current_tty_ops();
     install_fd_entry(
         process_id,
         tty_ops,
         tty_idx.0 as usize,
-        flags,
+        OpenMode::READ | OpenMode::WRITE,
         Some(tty_idx),
     )
 }
@@ -579,8 +598,16 @@ pub fn file_pipe_create(
 
         let nonblock = (flags & O_NONBLOCK as u32) != 0;
         let cloexec = (flags & O_CLOEXEC as u32) != 0;
-        let read_flags = FILE_OPEN_READ | if nonblock { O_NONBLOCK as u32 } else { 0 };
-        let write_flags = FILE_OPEN_WRITE | if nonblock { O_NONBLOCK as u32 } else { 0 };
+        let read_flags = if nonblock {
+            OpenMode::READ.with_raw(O_NONBLOCK as u32)
+        } else {
+            OpenMode::READ
+        };
+        let write_flags = if nonblock {
+            OpenMode::WRITE.with_raw(O_NONBLOCK as u32)
+        } else {
+            OpenMode::WRITE
+        };
 
         let Some(read_open_idx) =
             alloc_open_file_entry(open_files, &PIPE_READ_OPS, pipe_id as usize, read_flags, 0)
@@ -829,7 +856,7 @@ pub fn file_fcntl_fd(process_id: u32, fd: c_int, cmd: u64, arg: u64) -> i64 {
             let guard = unsafe { (&(*table_ptr).lock).lock() };
             let val = (unsafe { get_fd_entry(&mut *table_ptr, fd) })
                 .and_then(|f| get_open_file_mut(open_files, f.open_file_idx))
-                .map(|o| o.status_flags as i64)
+                .map(|o| o.status_flags.bits() as i64)
                 .unwrap_or(Errno::EBADF.raw() as i64);
             drop(guard);
             val
@@ -851,15 +878,19 @@ pub fn file_fcntl_fd(process_id: u32, fd: c_int, cmd: u64, arg: u64) -> i64 {
                 drop(guard);
                 return Errno::EBADF.raw() as i64;
             };
-            let mode_bits = open_file.status_flags & (FILE_OPEN_READ | FILE_OPEN_WRITE);
-            let sticky_flags = open_file.status_flags & (O_NOCTTY as u32);
-            let mut next_flags = mode_bits | sticky_flags | (arg as u32 & FILE_OPEN_APPEND);
-            if (arg & O_NONBLOCK) != 0 {
-                next_flags |= O_NONBLOCK as u32;
+            let mode_bits = open_file.status_flags & (OpenMode::READ | OpenMode::WRITE);
+            let mut next_flags = mode_bits;
+            if (arg as u32 & OpenMode::APPEND.bits()) != 0 {
+                next_flags |= OpenMode::APPEND;
             }
+            let mut raw = open_file.status_flags.bits() & (O_NOCTTY as u32);
+            if (arg & O_NONBLOCK) != 0 {
+                raw |= O_NONBLOCK as u32;
+            }
+            let next_flags = next_flags.with_raw(raw);
             open_file.status_flags = next_flags;
             if let Some(ops) = open_file.ops {
-                let _ = ops.set_status_flags(open_file.handle, next_flags);
+                let _ = ops.set_status_flags(open_file.handle, next_flags.bits());
             }
             drop(guard);
             0
@@ -902,7 +933,7 @@ pub fn fileio_open_socket_fd(process_id: u32, socket_idx: u32) -> i32 {
         process_id,
         socket_ops,
         socket_idx as usize,
-        FILE_OPEN_READ | FILE_OPEN_WRITE,
+        OpenMode::READ | OpenMode::WRITE,
         None,
     )
 }

--- a/fs/src/fileio/fdops.rs
+++ b/fs/src/fileio/fdops.rs
@@ -548,15 +548,21 @@ pub fn file_get_tty_index(process_id: u32, fd: c_int) -> Option<TtyIndex> {
 /// Open a file descriptor for a TTY device.
 ///
 /// TTY devices are inherently bidirectional, so READ and WRITE are always
-/// granted.  There is no `flags` parameter — callers cannot accidentally
-/// pass unconverted POSIX flags (the bug that `OpenMode` prevents).
-pub fn file_open_tty_fd(process_id: u32, tty_idx: TtyIndex) -> c_int {
+/// granted.  `posix_flags` is honoured only for `O_CLOEXEC`; pass `0` when
+/// no special flags are needed.
+pub fn file_open_tty_fd(process_id: u32, tty_idx: TtyIndex, posix_flags: u32) -> c_int {
     let tty_ops = current_tty_ops();
+    let base = OpenMode::READ | OpenMode::WRITE;
+    let flags = if posix_flags & O_CLOEXEC as u32 != 0 {
+        base.with_raw(O_CLOEXEC as u32)
+    } else {
+        base
+    };
     install_fd_entry(
         process_id,
         tty_ops,
         tty_idx.0 as usize,
-        OpenMode::READ | OpenMode::WRITE,
+        flags,
         Some(tty_idx),
     )
 }
@@ -856,7 +862,7 @@ pub fn file_fcntl_fd(process_id: u32, fd: c_int, cmd: u64, arg: u64) -> i64 {
             let guard = unsafe { (&(*table_ptr).lock).lock() };
             let val = (unsafe { get_fd_entry(&mut *table_ptr, fd) })
                 .and_then(|f| get_open_file_mut(open_files, f.open_file_idx))
-                .map(|o| o.status_flags.bits() as i64)
+                .map(|o| openmode_to_posix_bits(o.status_flags) as i64)
                 .unwrap_or(Errno::EBADF.raw() as i64);
             drop(guard);
             val
@@ -878,19 +884,20 @@ pub fn file_fcntl_fd(process_id: u32, fd: c_int, cmd: u64, arg: u64) -> i64 {
                 drop(guard);
                 return Errno::EBADF.raw() as i64;
             };
+            let posix_arg = arg as u32;
             let mode_bits = open_file.status_flags & (OpenMode::READ | OpenMode::WRITE);
             let mut next_flags = mode_bits;
-            if (arg as u32 & OpenMode::APPEND.bits()) != 0 {
+            if posix_arg & O_APPEND != 0 {
                 next_flags |= OpenMode::APPEND;
             }
             let mut raw = open_file.status_flags.bits() & (O_NOCTTY as u32);
-            if (arg & O_NONBLOCK) != 0 {
+            if posix_arg & O_NONBLOCK as u32 != 0 {
                 raw |= O_NONBLOCK as u32;
             }
             let next_flags = next_flags.with_raw(raw);
             open_file.status_flags = next_flags;
             if let Some(ops) = open_file.ops {
-                let _ = ops.set_status_flags(open_file.handle, next_flags.bits());
+                let _ = ops.set_status_flags(open_file.handle, openmode_to_posix_bits(next_flags));
             }
             drop(guard);
             0

--- a/fs/src/fileio/fdops.rs
+++ b/fs/src/fileio/fdops.rs
@@ -7,8 +7,8 @@ use slopos_abi::Errno;
 use slopos_abi::fs::UserFsEntry;
 use slopos_abi::io::{IoBufRead, IoBufWrite};
 use slopos_abi::syscall::{
-    F_DUPFD, F_GETFD, F_GETFL, F_SETFD, F_SETFL, FD_CLOEXEC, O_CLOEXEC, SEEK_CUR, SEEK_END,
-    SEEK_SET,
+    F_DUPFD, F_GETFD, F_GETFL, F_SETFD, F_SETFL, FD_CLOEXEC, O_CLOEXEC, O_NOCTTY, O_NONBLOCK,
+    SEEK_CUR, SEEK_END, SEEK_SET,
 };
 
 use crate::pipe;
@@ -548,16 +548,13 @@ pub fn file_get_tty_index(process_id: u32, fd: c_int) -> Option<TtyIndex> {
 /// Open a file descriptor for a TTY device.
 ///
 /// TTY devices are inherently bidirectional, so READ and WRITE are always
-/// granted.  `posix_flags` is honoured only for `O_CLOEXEC`; pass `0` when
-/// no special flags are needed.
+/// granted.  `posix_flags` is honoured for `O_CLOEXEC`, `O_NOCTTY`, and
+/// `O_NONBLOCK`; pass `0` when no special flags are needed.
 pub fn file_open_tty_fd(process_id: u32, tty_idx: TtyIndex, posix_flags: u32) -> c_int {
     let tty_ops = current_tty_ops();
     let base = OpenMode::READ | OpenMode::WRITE;
-    let flags = if posix_flags & O_CLOEXEC as u32 != 0 {
-        base.with_raw(O_CLOEXEC as u32)
-    } else {
-        base
-    };
+    let kept = posix_flags & (O_CLOEXEC as u32 | O_NOCTTY as u32 | O_NONBLOCK as u32);
+    let flags = if kept != 0 { base.with_raw(kept) } else { base };
     install_fd_entry(
         process_id,
         tty_ops,

--- a/fs/src/fileio/fdtable.rs
+++ b/fs/src/fileio/fdtable.rs
@@ -9,8 +9,8 @@ fn bootstrap_console_fds(
     let tty_ops = effective_tty_ops(external_ops);
 
     let console_tty = tty::default_console_tty();
-    let stdin_flags = FILE_OPEN_READ;
-    let stdout_flags = FILE_OPEN_WRITE;
+    let stdin_flags = OpenMode::READ;
+    let stdout_flags = OpenMode::WRITE;
 
     let mut opened_refs = 0u8;
     for _ in 0..3 {

--- a/fs/src/fileio/mod.rs
+++ b/fs/src/fileio/mod.rs
@@ -32,7 +32,7 @@ pub(super) const FILEIO_MAX_OPEN_FILE_ENTRIES: usize = 256;
 /// "no permissions" because `FILE_OPEN_READ` was 1.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct OpenMode(u32);
+pub(crate) struct OpenMode(u32);
 
 impl OpenMode {
     pub const EMPTY: Self = Self(0);
@@ -87,7 +87,7 @@ impl core::ops::BitAnd for OpenMode {
 }
 
 /// Convert POSIX `O_*` flags to internal `OpenMode`.
-pub fn posix_to_open_mode(posix: u32) -> OpenMode {
+pub(crate) fn posix_to_open_mode(posix: u32) -> OpenMode {
     let mut m = OpenMode::EMPTY;
     match posix & O_ACCMODE {
         O_RDONLY => m |= OpenMode::READ,
@@ -103,6 +103,24 @@ pub fn posix_to_open_mode(posix: u32) -> OpenMode {
     }
     // Pass through remaining POSIX bits (O_NONBLOCK, O_NOCTTY, etc.)
     m.with_raw(posix & !(O_ACCMODE | O_CREAT | O_APPEND))
+}
+
+/// Convert internal `OpenMode` status flags back to POSIX `O_*` bits (for `F_GETFL`).
+pub(crate) fn openmode_to_posix_bits(mode: OpenMode) -> u32 {
+    let mut posix = match (
+        mode.contains(OpenMode::READ),
+        mode.contains(OpenMode::WRITE),
+    ) {
+        (true, true) => O_RDWR,
+        (false, true) => O_WRONLY,
+        _ => O_RDONLY,
+    };
+    if mode.contains(OpenMode::APPEND) {
+        posix |= O_APPEND;
+    }
+    // O_NONBLOCK and O_NOCTTY are stored at their POSIX positions via with_raw().
+    posix |= mode.bits() & (O_NONBLOCK as u32 | O_NOCTTY as u32);
+    posix
 }
 
 #[derive(Clone, Copy)]

--- a/fs/src/fileio/mod.rs
+++ b/fs/src/fileio/mod.rs
@@ -24,26 +24,85 @@ use crate::MAX_PATH_LEN;
 pub(super) const FILEIO_MAX_OPEN_FILES: usize = 32;
 pub(super) const FILEIO_MAX_OPEN_FILE_ENTRIES: usize = 256;
 
-pub(super) const FILE_OPEN_READ: u32 = 1 << 0;
-pub(super) const FILE_OPEN_WRITE: u32 = 1 << 1;
-pub(super) const FILE_OPEN_CREAT: u32 = 1 << 2;
-pub(super) const FILE_OPEN_APPEND: u32 = 1 << 3;
+/// Internal open-mode flags for `OpenFileEntry`.
+///
+/// These are a DISTINCT type from POSIX `O_*` flags (`u32`).  Passing raw
+/// POSIX flags where `OpenMode` is expected is a compile error — preventing
+/// the class of bugs where `O_RDONLY` (0) is silently misinterpreted as
+/// "no permissions" because `FILE_OPEN_READ` was 1.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct OpenMode(u32);
 
-pub(super) fn posix_to_internal_flags(posix: u32) -> u32 {
-    let mut f = 0u32;
+impl OpenMode {
+    pub const EMPTY: Self = Self(0);
+    pub const READ: Self = Self(1 << 0);
+    pub const WRITE: Self = Self(1 << 1);
+    pub const CREAT: Self = Self(1 << 2);
+    pub const APPEND: Self = Self(1 << 3);
+
+    pub const fn contains(self, flag: Self) -> bool {
+        (self.0 & flag.0) == flag.0 && flag.0 != 0
+    }
+
+    pub const fn intersects(self, flag: Self) -> bool {
+        (self.0 & flag.0) != 0
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Merge pass-through POSIX bits (O_NONBLOCK, O_NOCTTY, etc.) that
+    /// live in the upper bits and don't collide with the internal flags.
+    pub const fn with_raw(self, raw: u32) -> Self {
+        Self(self.0 | raw)
+    }
+}
+
+impl Default for OpenMode {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+impl core::ops::BitOr for OpenMode {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitOrAssign for OpenMode {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl core::ops::BitAnd for OpenMode {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+/// Convert POSIX `O_*` flags to internal `OpenMode`.
+pub fn posix_to_open_mode(posix: u32) -> OpenMode {
+    let mut m = OpenMode::EMPTY;
     match posix & O_ACCMODE {
-        O_RDONLY => f |= FILE_OPEN_READ,
-        O_WRONLY => f |= FILE_OPEN_WRITE,
-        O_RDWR => f |= FILE_OPEN_READ | FILE_OPEN_WRITE,
+        O_RDONLY => m |= OpenMode::READ,
+        O_WRONLY => m |= OpenMode::WRITE,
+        O_RDWR => m |= OpenMode::READ | OpenMode::WRITE,
         _ => {}
     }
     if posix & O_CREAT != 0 {
-        f |= FILE_OPEN_CREAT;
+        m |= OpenMode::CREAT;
     }
     if posix & O_APPEND != 0 {
-        f |= FILE_OPEN_APPEND;
+        m |= OpenMode::APPEND;
     }
-    f | (posix & !(O_ACCMODE | O_CREAT | O_APPEND))
+    // Pass through remaining POSIX bits (O_NONBLOCK, O_NOCTTY, etc.)
+    m.with_raw(posix & !(O_ACCMODE | O_CREAT | O_APPEND))
 }
 
 #[derive(Clone, Copy)]
@@ -64,7 +123,7 @@ pub(super) struct OpenFileEntry {
     pub(super) ops: Option<&'static dyn FileOps>,
     pub(super) handle: usize,
     pub(super) position: u64,
-    pub(super) status_flags: u32,
+    pub(super) status_flags: OpenMode,
     pub(super) refcount: u16,
     pub(super) generation: u16,
     pub(super) valid: bool,
@@ -76,7 +135,7 @@ impl OpenFileEntry {
             ops: None,
             handle: 0,
             position: 0,
-            status_flags: 0,
+            status_flags: OpenMode::EMPTY,
             refcount: 0,
             generation: 0,
             valid: false,

--- a/fs/src/fileio/open_file_table.rs
+++ b/fs/src/fileio/open_file_table.rs
@@ -4,7 +4,7 @@ pub(super) fn alloc_open_file_entry(
     open_files: &mut [OpenFileEntry; FILEIO_MAX_OPEN_FILE_ENTRIES],
     ops: &'static dyn FileOps,
     handle: usize,
-    status_flags: u32,
+    status_flags: OpenMode,
     position: u64,
 ) -> Option<u16> {
     for (idx, slot) in open_files.iter_mut().enumerate() {
@@ -72,7 +72,7 @@ pub(super) fn release_open_file(
     slot.ops = None;
     slot.handle = 0;
     slot.position = 0;
-    slot.status_flags = 0;
+    slot.status_flags = OpenMode::EMPTY;
     slot.refcount = 0;
     slot.valid = false;
 }

--- a/ktesting/src/runner.rs
+++ b/ktesting/src/runner.rs
@@ -1,10 +1,9 @@
 use super::TestResult;
 
-pub fn run_single_test(_name: &str, test_fn: fn() -> TestResult) -> TestResult {
-    // Run the test directly. Panics propagate to the default panic handler,
-    // which exits QEMU with a failure code in test mode. This avoids
-    // deadlocks from longjmp through held locks or corrupted state.
-    // When intentional panic-testing is needed, add a dedicated
-    // run_single_test_expect_panic() that uses catch_panic!.
-    test_fn()
+pub fn run_single_test(name: &str, test_fn: fn() -> TestResult) -> TestResult {
+    let result = test_fn();
+    if !result.is_pass() {
+        slopos_utils::klog_info!("TEST FAIL: {}: {:?}", name, result);
+    }
+    result
 }

--- a/userland/src/apps/curl.rs
+++ b/userland/src/apps/curl.rs
@@ -935,8 +935,8 @@ fn execute_request(
         _pad: [0; 8],
     };
 
-    if net::connect(fd, &addr).is_err() {
-        let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+    if net::connect(fd.raw(), &addr).is_err() {
+        let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
         return Err(CurlError::ConnectFailed);
     }
 
@@ -947,14 +947,14 @@ fn execute_request(
         }
     }
 
-    if send_all(fd, &req).is_err() {
-        let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+    if send_all(fd.raw(), &req).is_err() {
+        let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
         return Err(CurlError::SendFailed);
     }
 
-    let _ = net::set_nonblocking(fd);
-    let result = receive_http_response(fd, config.verbose);
-    let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+    let _ = net::set_nonblocking(fd.raw());
+    let result = receive_http_response(fd.raw(), config.verbose);
+    let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
     result
 }
 

--- a/userland/src/apps/nc/tcp.rs
+++ b/userland/src/apps/nc/tcp.rs
@@ -17,7 +17,7 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
     };
 
     if config.local_port != 0 {
-        if let Err(_) = net::bind_any(fd, config.local_port) {
+        if let Err(_) = net::bind_any(fd.raw(), config.local_port) {
             write_stdout(b"nc: bind failed (port in use?)\n");
             return 1;
         }
@@ -37,7 +37,7 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
         config.remote_port,
     );
 
-    if let Err(e) = net::connect(fd, &dest) {
+    if let Err(e) = net::connect(fd.raw(), &dest) {
         write_stdout(b"nc: connect failed: ");
         write_stdout(e.as_str().as_bytes());
         write_stdout(b"\n");
@@ -52,7 +52,7 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
     );
     verbose_msg(config, "protocol: tcp");
 
-    if let Err(_) = net::set_nonblocking(fd) {
+    if let Err(_) = net::set_nonblocking(fd.raw()) {
         write_stdout(b"nc: failed to set non-blocking\n");
         return 1;
     }
@@ -73,7 +73,7 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
                 revents: 0,
             },
             UserPollFd {
-                fd,
+                fd: fd.raw(),
                 events: POLLIN,
                 revents: 0,
             },
@@ -86,7 +86,7 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
                 Ok(0) => {
                     stdin_closed = true;
                     verbose_msg(config, "stdin EOF");
-                    let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_WR);
+                    let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_WR);
                 }
                 Ok(n) => {
                     for i in 0..n {
@@ -96,21 +96,22 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
                             &mut line_pos,
                         ) {
                             StdinResult::SendLine(len) => {
-                                match net::send(fd, &line_buf[..len], 0) {
+                                match net::send(fd.raw(), &line_buf[..len], 0) {
                                     Ok(sent) => {
                                         verbose_bytes(config, "sent ", sent);
                                         last_activity_ms = clock_start.elapsed().as_millis() as u64;
                                     }
                                     Err(_) => {
                                         write_stdout(b"nc: send failed (broken pipe)\n");
-                                        let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                                        let _ =
+                                            net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                                         return 1;
                                     }
                                 }
                                 line_pos = 0;
                             }
                             StdinResult::Quit => {
-                                let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                                let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                                 return 0;
                             }
                             StdinResult::Continue => {}
@@ -122,10 +123,10 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
         }
 
         if (pfds[1].revents & POLLIN) != 0 {
-            match net::recv(fd, &mut recv_buf, 0) {
+            match net::recv(fd.raw(), &mut recv_buf, 0) {
                 Ok(0) => {
                     verbose_msg(config, "connection closed by remote");
-                    let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                    let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                     return 0;
                 }
                 Ok(received) => {
@@ -142,7 +143,7 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
 
         if (pfds[1].revents & (slopos_abi::syscall::POLLHUP | slopos_abi::syscall::POLLERR)) != 0 {
             verbose_msg(config, "connection closed");
-            let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+            let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
             return 0;
         }
 
@@ -150,7 +151,7 @@ pub(super) fn tcp_client(config: &NcConfig) -> u8 {
             let now = clock_start.elapsed().as_millis() as u64;
             if now.wrapping_sub(last_activity_ms) >= config.timeout_ms as u64 {
                 write_stdout(b"nc: timeout\n");
-                let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                 return 1;
             }
         }
@@ -166,19 +167,19 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
         }
     };
 
-    let _ = net::set_reuse_addr(fd);
+    let _ = net::set_reuse_addr(fd.raw());
 
-    if let Err(_) = net::bind_any(fd, config.local_port) {
+    if let Err(_) = net::bind_any(fd.raw(), config.local_port) {
         write_stdout(b"nc: bind failed (port in use?)\n");
         return 1;
     }
 
-    if let Err(_) = net::listen(fd, 1) {
+    if let Err(_) = net::listen(fd.raw(), 1) {
         write_stdout(b"nc: listen failed\n");
         return 1;
     }
 
-    if let Err(_) = net::set_nonblocking(fd) {
+    if let Err(_) = net::set_nonblocking(fd.raw()) {
         write_stdout(b"nc: failed to set non-blocking\n");
         return 1;
     }
@@ -200,12 +201,12 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                 let elapsed = accept_start.elapsed().as_millis() as u64;
                 if elapsed >= config.timeout_ms as u64 {
                     write_stdout(b"nc: timeout waiting for connection\n");
-                    let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                    let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                     return 1;
                 }
             }
 
-            match net::accept(fd, Some(&mut peer)) {
+            match net::accept(fd.raw(), Some(&mut peer)) {
                 Ok(cfd) => break cfd,
                 Err(_) => thread::sleep(Duration::from_millis(10)),
             }
@@ -218,9 +219,9 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
             u16::from_be(peer.port),
         );
 
-        if let Err(_) = net::set_nonblocking(client_fd) {
+        if let Err(_) = net::set_nonblocking(client_fd.raw()) {
             write_stdout(b"nc: failed to set non-blocking on client socket\n");
-            let _ = net::shutdown(client_fd, slopos_abi::syscall::SHUT_RDWR);
+            let _ = net::shutdown(client_fd.raw(), slopos_abi::syscall::SHUT_RDWR);
             if !config.keep_listen {
                 return 1;
             }
@@ -242,7 +243,7 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                     revents: 0,
                 },
                 UserPollFd {
-                    fd: client_fd,
+                    fd: client_fd.raw(),
                     events: POLLIN,
                     revents: 0,
                 },
@@ -255,7 +256,7 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                     Ok(0) => {
                         stdin_closed = true;
                         verbose_msg(config, "stdin EOF");
-                        let _ = net::shutdown(client_fd, slopos_abi::syscall::SHUT_WR);
+                        let _ = net::shutdown(client_fd.raw(), slopos_abi::syscall::SHUT_WR);
                     }
                     Ok(n) => {
                         for i in 0..n {
@@ -265,7 +266,7 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                                 &mut line_pos,
                             ) {
                                 StdinResult::SendLine(len) => {
-                                    match net::send(client_fd, &line_buf[..len], 0) {
+                                    match net::send(client_fd.raw(), &line_buf[..len], 0) {
                                         Ok(sent) => {
                                             verbose_bytes(config, "sent ", sent);
                                             last_activity_ms =
@@ -274,7 +275,7 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                                         Err(_) => {
                                             write_stdout(b"nc: send failed (broken pipe)\n");
                                             let _ = net::shutdown(
-                                                client_fd,
+                                                client_fd.raw(),
                                                 slopos_abi::syscall::SHUT_RDWR,
                                             );
                                             break 'client Some(1u8);
@@ -283,8 +284,10 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                                     line_pos = 0;
                                 }
                                 StdinResult::Quit => {
-                                    let _ =
-                                        net::shutdown(client_fd, slopos_abi::syscall::SHUT_RDWR);
+                                    let _ = net::shutdown(
+                                        client_fd.raw(),
+                                        slopos_abi::syscall::SHUT_RDWR,
+                                    );
                                     break 'client Some(0u8);
                                 }
                                 StdinResult::Continue => {}
@@ -296,10 +299,10 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
             }
 
             if (pfds[1].revents & POLLIN) != 0 {
-                match net::recv(client_fd, &mut recv_buf, 0) {
+                match net::recv(client_fd.raw(), &mut recv_buf, 0) {
                     Ok(0) => {
                         verbose_msg(config, "connection closed by remote");
-                        let _ = net::shutdown(client_fd, slopos_abi::syscall::SHUT_RDWR);
+                        let _ = net::shutdown(client_fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                         break 'client None;
                     }
                     Ok(received) => {
@@ -318,7 +321,7 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                 != 0
             {
                 verbose_msg(config, "connection closed");
-                let _ = net::shutdown(client_fd, slopos_abi::syscall::SHUT_RDWR);
+                let _ = net::shutdown(client_fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                 break 'client None;
             }
 
@@ -326,20 +329,20 @@ pub(super) fn tcp_listen(config: &NcConfig) -> u8 {
                 let now = clock_start.elapsed().as_millis() as u64;
                 if now.wrapping_sub(last_activity_ms) >= config.timeout_ms as u64 {
                     write_stdout(b"nc: timeout\n");
-                    let _ = net::shutdown(client_fd, slopos_abi::syscall::SHUT_RDWR);
+                    let _ = net::shutdown(client_fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                     break 'client None;
                 }
             }
         };
 
         if let Some(code) = client_exit {
-            let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+            let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
             return code;
         }
 
         if !config.keep_listen {
             verbose_msg(config, "exiting (single connection mode)");
-            let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+            let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
             return 0;
         }
 

--- a/userland/src/apps/nc/udp.rs
+++ b/userland/src/apps/nc/udp.rs
@@ -17,13 +17,13 @@ pub(super) fn udp_client(config: &NcConfig) -> u8 {
     };
 
     if config.local_port != 0 {
-        if let Err(_) = net::bind_any(fd, config.local_port) {
+        if let Err(_) = net::bind_any(fd.raw(), config.local_port) {
             write_stdout(b"nc: bind failed (port in use?)\n");
             return 1;
         }
     }
 
-    if let Err(_) = net::set_nonblocking(fd) {
+    if let Err(_) = net::set_nonblocking(fd.raw()) {
         write_stdout(b"nc: failed to set non-blocking\n");
         return 1;
     }
@@ -59,7 +59,7 @@ pub(super) fn udp_client(config: &NcConfig) -> u8 {
                 revents: 0,
             },
             UserPollFd {
-                fd,
+                fd: fd.raw(),
                 events: POLLIN,
                 revents: 0,
             },
@@ -81,7 +81,7 @@ pub(super) fn udp_client(config: &NcConfig) -> u8 {
                             &mut line_pos,
                         ) {
                             StdinResult::SendLine(len) => {
-                                match net::sendto(fd, &line_buf[..len], 0, &dest) {
+                                match net::sendto(fd.raw(), &line_buf[..len], 0, &dest) {
                                     Ok(sent) => {
                                         verbose_bytes(config, "sent ", sent);
                                         last_activity_ms = clock_start.elapsed().as_millis() as u64;
@@ -93,7 +93,7 @@ pub(super) fn udp_client(config: &NcConfig) -> u8 {
                                 line_pos = 0;
                             }
                             StdinResult::Quit => {
-                                let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                                let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                                 return 0;
                             }
                             StdinResult::Continue => {}
@@ -106,7 +106,7 @@ pub(super) fn udp_client(config: &NcConfig) -> u8 {
 
         if (pfds[1].revents & POLLIN) != 0 {
             let mut src_addr = SockAddrIn::default();
-            match net::recvfrom(fd, &mut recv_buf, 0, Some(&mut src_addr)) {
+            match net::recvfrom(fd.raw(), &mut recv_buf, 0, Some(&mut src_addr)) {
                 Ok(0) => {}
                 Ok(received) => {
                     write_stdout(&recv_buf[..received]);
@@ -124,7 +124,7 @@ pub(super) fn udp_client(config: &NcConfig) -> u8 {
             let now = clock_start.elapsed().as_millis() as u64;
             if now.wrapping_sub(last_activity_ms) >= config.timeout_ms as u64 {
                 write_stdout(b"nc: timeout\n");
-                let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                 return 1;
             }
         }
@@ -140,14 +140,14 @@ pub(super) fn udp_listen(config: &NcConfig) -> u8 {
         }
     };
 
-    let _ = net::set_reuse_addr(fd);
+    let _ = net::set_reuse_addr(fd.raw());
 
-    if let Err(_) = net::bind_any(fd, config.local_port) {
+    if let Err(_) = net::bind_any(fd.raw(), config.local_port) {
         write_stdout(b"nc: bind failed (port in use?)\n");
         return 1;
     }
 
-    if let Err(_) = net::set_nonblocking(fd) {
+    if let Err(_) = net::set_nonblocking(fd.raw()) {
         write_stdout(b"nc: failed to set non-blocking\n");
         return 1;
     }
@@ -177,7 +177,7 @@ pub(super) fn udp_listen(config: &NcConfig) -> u8 {
                 revents: 0,
             },
             UserPollFd {
-                fd,
+                fd: fd.raw(),
                 events: POLLIN,
                 revents: 0,
             },
@@ -200,7 +200,7 @@ pub(super) fn udp_listen(config: &NcConfig) -> u8 {
                         ) {
                             StdinResult::SendLine(len) => {
                                 if has_peer {
-                                    match net::sendto(fd, &line_buf[..len], 0, &last_peer) {
+                                    match net::sendto(fd.raw(), &line_buf[..len], 0, &last_peer) {
                                         Ok(sent) => {
                                             verbose_bytes(config, "sent ", sent);
                                             last_activity_ms =
@@ -214,7 +214,7 @@ pub(super) fn udp_listen(config: &NcConfig) -> u8 {
                                 line_pos = 0;
                             }
                             StdinResult::Quit => {
-                                let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                                let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                                 return 0;
                             }
                             StdinResult::Continue => {}
@@ -227,7 +227,7 @@ pub(super) fn udp_listen(config: &NcConfig) -> u8 {
 
         if (pfds[1].revents & POLLIN) != 0 {
             let mut src_addr = SockAddrIn::default();
-            match net::recvfrom(fd, &mut recv_buf, 0, Some(&mut src_addr)) {
+            match net::recvfrom(fd.raw(), &mut recv_buf, 0, Some(&mut src_addr)) {
                 Ok(0) => {}
                 Ok(received) => {
                     write_stdout(&recv_buf[..received]);
@@ -252,7 +252,7 @@ pub(super) fn udp_listen(config: &NcConfig) -> u8 {
             let now = clock_start.elapsed().as_millis() as u64;
             if now.wrapping_sub(last_activity_ms) >= config.timeout_ms as u64 {
                 write_stdout(b"nc: timeout\n");
-                let _ = net::shutdown(fd, slopos_abi::syscall::SHUT_RDWR);
+                let _ = net::shutdown(fd.raw(), slopos_abi::syscall::SHUT_RDWR);
                 return 1;
             }
         }

--- a/userland/src/apps/ping.rs
+++ b/userland/src/apps/ping.rs
@@ -338,12 +338,12 @@ pub fn ping_main(args: Vec<String>) -> ! {
     };
 
     let ident = (process::getpid() & 0xFFFF) as u16;
-    if let Err(_) = net::bind_addr(fd, [0, 0, 0, 0], ident) {
+    if let Err(_) = net::bind_addr(fd.raw(), [0, 0, 0, 0], ident) {
         write_stdout(b"ping: bind failed\n");
         std::process::exit(2);
     }
 
-    if let Err(_) = net::set_nonblocking(fd) {
+    if let Err(_) = net::set_nonblocking(fd.raw()) {
         write_stdout(b"ping: failed to set non-blocking\n");
         std::process::exit(2);
     }
@@ -388,7 +388,7 @@ pub fn ping_main(args: Vec<String>) -> ! {
 
         if !stop_requested && !all_sent && now >= next_send {
             if !send_ping(
-                fd,
+                fd.raw(),
                 &target,
                 ident,
                 sequence,
@@ -416,7 +416,7 @@ pub fn ping_main(args: Vec<String>) -> ! {
 
         let (stdin_ready, socket_ready, timed_out) = if stop_requested {
             let mut pfd = [UserPollFd {
-                fd,
+                fd: fd.raw(),
                 events: POLLIN,
                 revents: 0,
             }];
@@ -430,7 +430,7 @@ pub fn ping_main(args: Vec<String>) -> ! {
                     revents: 0,
                 },
                 UserPollFd {
-                    fd,
+                    fd: fd.raw(),
                     events: POLLIN,
                     revents: 0,
                 },
@@ -444,10 +444,10 @@ pub fn ping_main(args: Vec<String>) -> ! {
         };
 
         if socket_ready {
-            try_receive(fd, &clock_start, &mut stats, config.verbose);
+            try_receive(fd.raw(), &clock_start, &mut stats, config.verbose);
         }
 
-        if stdin_ready && !stop_requested && stdin_has_ctrl_c() {
+        if !stop_requested && stdin_ready && stdin_has_ctrl_c() {
             write_stdout(b"^C\n");
             stop_requested = true;
             continue;

--- a/userland/src/apps/shell/exec.rs
+++ b/userland/src/apps/shell/exec.rs
@@ -389,27 +389,42 @@ fn print_background_job_started(job_id: u16, pid: u32) {
     shell_write(b"\n");
 }
 
-fn drain_compositor_signals() {
+/// Forward compositor keyboard events to the PTY master so the slave's
+/// line discipline handles ISIG signal generation, echo, and canonical
+/// editing.  Also drains PTY master output (echo bytes) to the display.
+///
+/// This replaces the old `drain_compositor_signals()` which bypassed the
+/// TTY and called `kill()` directly — breaking ISIG semantics, preventing
+/// child stdin reads, and only handling Ctrl+C (not Ctrl+Z/Ctrl+\).
+fn forward_compositor_keyboard() {
     use crate::syscall::{InputEvent, InputEventType, input};
-    use slopos_abi::signal::SIGINT;
 
     if !super::display::DISPLAY.enabled.get() {
         return;
     }
+    let master = super::shell_pty_master();
+    if master < 0 {
+        return;
+    }
+    let master_idx = master as u32;
+
+    // Forward keyboard bytes to PTY master → slave ldisc processes them.
     let mut events = [InputEvent::default(); 8];
     let count = input::poll_batch(&mut events) as usize;
     for i in 0..count.min(8) {
         if events[i].event_type == InputEventType::KeyPress {
             let ascii = events[i].key_ascii();
-            if ascii == 0x03 {
-                let fg = foreground_pgid();
-                if fg != 0 {
-                    if let Ok(group) = i32::try_from(fg) {
-                        let _ = process::kill_pid(-group, SIGINT);
-                    }
-                }
+            if ascii != 0 {
+                let _ = process::tty_write(master_idx, &[ascii]);
             }
         }
+    }
+
+    // Drain echo/output from the PTY master and display it.
+    let mut echo_buf = [0u8; 256];
+    let n = process::tty_read(master_idx, &mut echo_buf);
+    if n > 0 {
+        super::display::shell_write(&echo_buf[..n as usize]);
     }
 }
 
@@ -423,28 +438,33 @@ fn execute_registry_spawn(cmd: &ParsedCommand, background: bool) -> Option<i32> 
     let mut backup_fd = -1i32;
 
     if capture {
-        if fs::pipe(&mut pipe_fds).is_err() {
-            shell_write(b"pipe failed\n");
-            return Some(1);
-        }
-        backup_fd = match fs::dup(1) {
-            Ok(fd) => fd,
+        let (r, w) = match fs::pipe() {
+            Ok(pair) => pair,
             Err(_) => {
-                let _ = fs::close_fd(pipe_fds[0]);
-                let _ = fs::close_fd(pipe_fds[1]);
+                shell_write(b"pipe failed\n");
+                return Some(1);
+            }
+        };
+        pipe_fds[0] = r.into_raw();
+        pipe_fds[1] = w.into_raw();
+        backup_fd = match fs::dup(1) {
+            Ok(fd) => fd.into_raw(),
+            Err(_) => {
+                let _ = fs::close_fd_raw(pipe_fds[0]);
+                let _ = fs::close_fd_raw(pipe_fds[1]);
                 shell_write(b"dup failed\n");
                 return Some(1);
             }
         };
         if fs::dup2(pipe_fds[1], 1).is_err() {
-            let _ = fs::close_fd(pipe_fds[0]);
-            let _ = fs::close_fd(pipe_fds[1]);
-            let _ = fs::close_fd(backup_fd);
+            let _ = fs::close_fd_raw(pipe_fds[0]);
+            let _ = fs::close_fd_raw(pipe_fds[1]);
+            let _ = fs::close_fd_raw(backup_fd);
             shell_write(b"dup2 failed\n");
             return Some(1);
         }
         // Close extra write-end; child will inherit fd 1 = pipe write.
-        let _ = fs::close_fd(pipe_fds[1]);
+        let _ = fs::close_fd_raw(pipe_fds[1]);
     }
 
     let spawn_flags = if background {
@@ -460,14 +480,13 @@ fn execute_registry_spawn(cmd: &ParsedCommand, background: bool) -> Option<i32> 
         spawn_flags,
     );
 
-    // Restore fd 1 immediately after spawn so shell output is normal again.
     if capture {
         let _ = fs::dup2(backup_fd, 1);
-        let _ = fs::close_fd(backup_fd);
+        let _ = fs::close_fd_raw(backup_fd);
     }
     if tid <= 0 {
         if capture {
-            let _ = fs::close_fd(pipe_fds[0]);
+            let _ = fs::close_fd_raw(pipe_fds[0]);
         }
         shell_write(b"spawn failed\n");
     }
@@ -508,7 +527,7 @@ fn execute_registry_spawn(cmd: &ParsedCommand, background: bool) -> Option<i32> 
             }];
             let _ = fs::poll(&mut pfds, 10);
 
-            drain_compositor_signals();
+            forward_compositor_keyboard();
 
             loop {
                 match fs::read_slice(pipe_fds[0], &mut buf) {
@@ -521,8 +540,6 @@ fn execute_registry_spawn(cmd: &ParsedCommand, background: bool) -> Option<i32> 
             }
 
             if let Some(st) = process::waitpid_nohang(pid) {
-                // Final drain — child is dead, pipe write-end closed,
-                // remaining data can be read without blocking.
                 loop {
                     match fs::read_slice(pipe_fds[0], &mut buf) {
                         Ok(0) => break,
@@ -536,14 +553,14 @@ fn execute_registry_spawn(cmd: &ParsedCommand, background: bool) -> Option<i32> 
                 break;
             }
         }
-        let _ = fs::close_fd(pipe_fds[0]);
+        let _ = fs::close_fd_raw(pipe_fds[0]);
         exit_status
     } else if super::display::DISPLAY.enabled.get() {
         loop {
             if let Some(st) = process::waitpid_nohang(pid) {
                 break st;
             }
-            drain_compositor_signals();
+            forward_compositor_keyboard();
             sys_core::sleep_ms(5);
         }
     } else {
@@ -561,13 +578,13 @@ fn open_redirect_target(redir: Redirect, path_buf: &mut [u8; 256]) -> Result<(i3
     match redir.kind {
         RedirectKind::Input => {
             let fd = fs::open_path(path_buf.as_ptr() as *const c_char, O_RDONLY).map_err(|_| ())?;
-            Ok((0, fd))
+            Ok((0, fd.into_raw()))
         }
         RedirectKind::OutputTruncate => {
             let _ = fs::unlink_path(path_buf.as_ptr() as *const c_char);
             let fd = fs::open_path(path_buf.as_ptr() as *const c_char, O_WRONLY | O_CREAT)
                 .map_err(|_| ())?;
-            Ok((1, fd))
+            Ok((1, fd.into_raw()))
         }
         RedirectKind::OutputAppend => {
             let fd = fs::open_path(
@@ -575,7 +592,7 @@ fn open_redirect_target(redir: Redirect, path_buf: &mut [u8; 256]) -> Result<(i3
                 O_WRONLY | O_CREAT | O_APPEND,
             )
             .map_err(|_| ())?;
-            Ok((1, fd))
+            Ok((1, fd.into_raw()))
         }
     }
 }
@@ -596,28 +613,28 @@ fn apply_redirects_for_builtin(
 
         if target_fd == 1 {
             if *output_fd >= 0 {
-                let _ = fs::close_fd(*output_fd);
+                let _ = fs::close_fd_raw(*output_fd);
             }
             *output_fd = opened_fd;
             continue;
         }
 
         let backup = match fs::dup(target_fd) {
-            Ok(fd) => fd,
+            Ok(fd) => fd.into_raw(),
             Err(_) => {
-                let _ = fs::close_fd(opened_fd);
+                let _ = fs::close_fd_raw(opened_fd);
                 shell_write(b"redirection failed\n");
                 return false;
             }
         };
 
         if fs::dup2(opened_fd, target_fd).is_err() {
-            let _ = fs::close_fd(opened_fd);
-            let _ = fs::close_fd(backup);
+            let _ = fs::close_fd_raw(opened_fd);
+            let _ = fs::close_fd_raw(backup);
             shell_write(b"redirection failed\n");
             return false;
         }
-        let _ = fs::close_fd(opened_fd);
+        let _ = fs::close_fd_raw(opened_fd);
 
         if save_count < saved.len() {
             saved[save_count] = SavedFd {
@@ -637,7 +654,7 @@ fn restore_redirects(saved: &mut [SavedFd; MAX_REDIRECTS]) {
             continue;
         }
         let _ = fs::dup2(slot.backup, slot.fd);
-        let _ = fs::close_fd(slot.backup);
+        let _ = fs::close_fd_raw(slot.backup);
         *slot = SavedFd::empty();
     }
 }
@@ -709,8 +726,8 @@ fn run_in_child(
     }
 
     for pipe in pipes.iter().take(pipe_count) {
-        let _ = fs::close_fd(pipe[0]);
-        let _ = fs::close_fd(pipe[1]);
+        let _ = fs::close_fd_raw(pipe[0]);
+        let _ = fs::close_fd_raw(pipe[1]);
     }
 
     if let Some(entry) = builtins::find_builtin(cmd.argv[0]) {
@@ -723,17 +740,17 @@ fn run_in_child(
             };
             if target_fd == 1 {
                 if builtin_output_fd != 1 {
-                    let _ = fs::close_fd(builtin_output_fd);
+                    let _ = fs::close_fd_raw(builtin_output_fd);
                 }
                 builtin_output_fd = opened_fd;
                 continue;
             }
             if fs::dup2(opened_fd, target_fd).is_err() {
                 let _ = crate::syscall::tty::write(b"redirection failed\n");
-                let _ = fs::close_fd(opened_fd);
+                let _ = fs::close_fd_raw(opened_fd);
                 sys_core::exit_with_code(1);
             }
-            let _ = fs::close_fd(opened_fd);
+            let _ = fs::close_fd_raw(opened_fd);
         }
 
         shell_set_output_fd(builtin_output_fd);
@@ -744,7 +761,7 @@ fn run_in_child(
         let code = (entry.func)(cmd.argc as i32, &args);
         shell_clear_output_fd();
         if builtin_output_fd != 1 {
-            let _ = fs::close_fd(builtin_output_fd);
+            let _ = fs::close_fd_raw(builtin_output_fd);
         }
         sys_core::exit_with_code(code);
     }
@@ -757,10 +774,10 @@ fn run_in_child(
         };
         if fs::dup2(opened_fd, target_fd).is_err() {
             let _ = crate::syscall::tty::write(b"redirection failed\n");
-            let _ = fs::close_fd(opened_fd);
+            let _ = fs::close_fd_raw(opened_fd);
             sys_core::exit_with_code(1);
         }
-        let _ = fs::close_fd(opened_fd);
+        let _ = fs::close_fd_raw(opened_fd);
     }
 
     let Some(path_ptr) = resolve_exec_path(cmd.argv[0], &mut path_buf) else {
@@ -786,7 +803,7 @@ fn execute_single_builtin(cmd: &ParsedCommand) -> i32 {
     if !apply_redirects_for_builtin(cmd, &mut saved, &mut output_fd) {
         restore_redirects(&mut saved);
         if output_fd >= 0 {
-            let _ = fs::close_fd(output_fd);
+            let _ = fs::close_fd_raw(output_fd);
         }
         return 1;
     }
@@ -810,7 +827,7 @@ fn execute_single_builtin(cmd: &ParsedCommand) -> i32 {
 
     restore_redirects(&mut saved);
     if output_fd >= 0 {
-        let _ = fs::close_fd(output_fd);
+        let _ = fs::close_fd_raw(output_fd);
     }
     code
 }
@@ -822,17 +839,23 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
     let total_pipes = inter_pipes + if capture_output { 1 } else { 0 };
     let mut pipes = [[-1; 2]; MAX_PIPE_CMDS];
     for pair in pipes.iter_mut().take(total_pipes) {
-        if fs::pipe(pair).is_err() {
-            shell_write(b"pipe failed\n");
-            for p in pipes.iter().take(total_pipes) {
-                if p[0] >= 0 {
-                    let _ = fs::close_fd(p[0]);
-                }
-                if p[1] >= 0 {
-                    let _ = fs::close_fd(p[1]);
-                }
+        match fs::pipe() {
+            Ok((r, w)) => {
+                pair[0] = r.into_raw();
+                pair[1] = w.into_raw();
             }
-            return 1;
+            Err(_) => {
+                shell_write(b"pipe failed\n");
+                for p in pipes.iter().take(total_pipes) {
+                    if p[0] >= 0 {
+                        let _ = fs::close_fd_raw(p[0]);
+                    }
+                    if p[1] >= 0 {
+                        let _ = fs::close_fd_raw(p[1]);
+                    }
+                }
+                return 1;
+            }
         }
     }
 
@@ -853,8 +876,8 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
         if pid < 0 {
             shell_write(b"fork failed\n");
             for pair in pipes.iter().take(total_pipes) {
-                let _ = fs::close_fd(pair[0]);
-                let _ = fs::close_fd(pair[1]);
+                let _ = fs::close_fd_raw(pair[0]);
+                let _ = fs::close_fd_raw(pair[1]);
             }
             return 1;
         }
@@ -881,12 +904,12 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
 
     for pair in pipes.iter().take(total_pipes) {
         if pair[1] >= 0 {
-            let _ = fs::close_fd(pair[1]);
+            let _ = fs::close_fd_raw(pair[1]);
         }
     }
     for pair in pipes.iter().take(inter_pipes) {
         if pair[0] >= 0 {
-            let _ = fs::close_fd(pair[0]);
+            let _ = fs::close_fd_raw(pair[0]);
         }
     }
 
@@ -916,7 +939,7 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
             }
             shell_write(&buf[..n]);
         }
-        let _ = fs::close_fd(capture_fd);
+        let _ = fs::close_fd_raw(capture_fd);
     }
 
     let mut status = 0;
@@ -927,7 +950,7 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
                     status = st;
                     break;
                 }
-                drain_compositor_signals();
+                forward_compositor_keyboard();
                 sys_core::sleep_ms(5);
             }
         } else {

--- a/userland/src/apps/shell/exec.rs
+++ b/userland/src/apps/shell/exec.rs
@@ -416,6 +416,23 @@ fn forward_compositor_keyboard() {
             let ascii = events[i].key_ascii();
             if ascii != 0 {
                 let _ = process::tty_write(master_idx, &[ascii]);
+            } else {
+                // Non-ASCII keys: convert scancode to VT100 escape sequence.
+                let seq: &[u8] = match events[i].key_scancode() {
+                    0x82 => b"\x1b[A",  // Up
+                    0x83 => b"\x1b[B",  // Down
+                    0x84 => b"\x1b[D",  // Left
+                    0x85 => b"\x1b[C",  // Right
+                    0x86 => b"\x1b[H",  // Home
+                    0x87 => b"\x1b[F",  // End
+                    0x88 => b"\x1b[3~", // Delete
+                    0x80 => b"\x1b[5~", // Page Up
+                    0x81 => b"\x1b[6~", // Page Down
+                    _ => &[],
+                };
+                if !seq.is_empty() {
+                    let _ = process::tty_write(master_idx, seq);
+                }
             }
         }
     }
@@ -936,6 +953,8 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
         let mut buf = [0u8; 512];
         let mut all_exited = false;
         let mut status = 0;
+        let cmd_count = pipeline.command_count;
+        let mut reaped = [false; 16];
         loop {
             let mut pfds = [UserPollFd {
                 fd: capture_fd,
@@ -958,9 +977,15 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
 
             if !all_exited {
                 let mut done = true;
-                for pid in pids.iter().take(pipeline.command_count) {
+                for (idx, pid) in pids.iter().take(cmd_count).enumerate() {
+                    if reaped[idx] {
+                        continue;
+                    }
                     if let Some(st) = process::waitpid_nohang(*pid) {
-                        status = st;
+                        reaped[idx] = true;
+                        if idx == cmd_count - 1 {
+                            status = st;
+                        }
                     } else {
                         done = false;
                     }

--- a/userland/src/apps/shell/exec.rs
+++ b/userland/src/apps/shell/exec.rs
@@ -489,6 +489,7 @@ fn execute_registry_spawn(cmd: &ParsedCommand, background: bool) -> Option<i32> 
             let _ = fs::close_fd_raw(pipe_fds[0]);
         }
         shell_write(b"spawn failed\n");
+        return Some(1);
     }
     let pid = tid as u32;
     if background {
@@ -927,6 +928,66 @@ fn execute_pipeline(pipeline: &ParsedPipeline) -> i32 {
     enter_foreground(pgid);
 
     let capture_fd = pipes[inter_pipes][0];
+    if capture_fd >= 0 && super::display::DISPLAY.enabled.get() {
+        // Display mode: non-blocking read + poll so we keep forwarding
+        // compositor keyboard events to the PTY (avoids deadlocking
+        // children that read from the TTY slave).
+        let _ = crate::syscall::net::set_nonblocking(capture_fd);
+        let mut buf = [0u8; 512];
+        let mut all_exited = false;
+        let mut status = 0;
+        loop {
+            let mut pfds = [UserPollFd {
+                fd: capture_fd,
+                events: POLLIN,
+                revents: 0,
+            }];
+            let _ = fs::poll(&mut pfds, 10);
+
+            forward_compositor_keyboard();
+
+            loop {
+                match fs::read_slice(capture_fd, &mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        shell_write(&buf[..n]);
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            if !all_exited {
+                let mut done = true;
+                for pid in pids.iter().take(pipeline.command_count) {
+                    if let Some(st) = process::waitpid_nohang(*pid) {
+                        status = st;
+                    } else {
+                        done = false;
+                    }
+                }
+                if done {
+                    all_exited = true;
+                }
+            } else {
+                // Children exited — drain remaining data then stop.
+                break;
+            }
+        }
+        // Final drain after children have exited.
+        loop {
+            match fs::read_slice(capture_fd, &mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    shell_write(&buf[..n]);
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = fs::close_fd_raw(capture_fd);
+        leave_foreground();
+        return status;
+    }
+
     if capture_fd >= 0 {
         let mut buf = [0u8; 512];
         loop {

--- a/userland/src/apps/shell/input.rs
+++ b/userland/src/apps/shell/input.rs
@@ -470,9 +470,6 @@ fn input_loop(
                     rd!();
                     continue;
                 }
-                if super::builtins::process::maybe_handle_ctrl_c() {
-                    continue;
-                }
                 shell_write(b"^C\n");
                 history::reset_cursor();
                 return 0;

--- a/userland/src/apps/shell/mod.rs
+++ b/userland/src/apps/shell/mod.rs
@@ -98,13 +98,21 @@ pub fn shell_pty_pair() -> Option<(u32, u32)> {
     }
 }
 
-/// Return the PTY master TTY index, or -1 if unavailable.
+/// Return the PTY master TTY index (not a file descriptor), or -1 if unavailable.
+///
+/// This is a kernel-internal TTY slot index used with `tty_write`/`tty_read`,
+/// not a POSIX file descriptor.  See [`SHELL_PTY_MASTER_FD`] for the fd.
 pub fn shell_pty_master() -> i32 {
     SHELL_PTY_MASTER.load(Ordering::Relaxed)
 }
 
+/// Raw file descriptor for the PTY master device.
+///
+/// Distinct from [`SHELL_PTY_MASTER`] which stores a kernel TTY slot index.
+/// This fd is obtained from `open_tty_fd` and can be used with `read`/`write`/`close`.
 static SHELL_PTY_MASTER_FD: AtomicI32 = AtomicI32::new(-1);
 
+/// Store the raw file descriptor for the PTY master device.
 fn set_shell_pty_master_fd(fd: i32) {
     SHELL_PTY_MASTER_FD.store(fd, Ordering::Relaxed);
 }

--- a/userland/src/apps/shell/mod.rs
+++ b/userland/src/apps/shell/mod.rs
@@ -98,6 +98,17 @@ pub fn shell_pty_pair() -> Option<(u32, u32)> {
     }
 }
 
+/// Return the PTY master TTY index, or -1 if unavailable.
+pub fn shell_pty_master() -> i32 {
+    SHELL_PTY_MASTER.load(Ordering::Relaxed)
+}
+
+static SHELL_PTY_MASTER_FD: AtomicI32 = AtomicI32::new(-1);
+
+fn set_shell_pty_master_fd(fd: i32) {
+    SHELL_PTY_MASTER_FD.store(fd, Ordering::Relaxed);
+}
+
 pub(crate) const PROMPT_BUF_MAX: usize = 280;
 
 // Fallback: matches the previous hardcoded `[/path] $ ` format.
@@ -279,8 +290,8 @@ pub fn shell_user_main() {
 fn shell_interactive_main() {
     use slopos_abi::signal::SIGINT;
 
-    use crate::syscall::process;
     use crate::syscall::window;
+    use crate::syscall::{fs, process};
 
     display::shell_console_init();
     display::shell_console_clear();
@@ -293,6 +304,13 @@ fn shell_interactive_main() {
     SHELL_PID.store(std::process::id(), Ordering::Relaxed);
     if let Ok((master, slave)) = process::openpty() {
         set_shell_pty_pair(master, slave);
+        if let Ok(master_fd) = process::open_tty_fd(master) {
+            if let Ok(slave_fd) = fs::ioctl_tiocgptpeer(master_fd.raw()) {
+                set_shell_pty_master_fd(master_fd.into_raw());
+                let _ = fs::dup2(slave_fd.raw(), 0);
+                // slave_fd dropped here, auto-closed
+            }
+        }
     }
     exec::initialize_job_control();
     let _ = process::ignore_signal(SIGINT);

--- a/userland/src/syscall/fs.rs
+++ b/userland/src/syscall/fs.rs
@@ -36,7 +36,8 @@ use slopos_slibc::pal::{Pal, Sys};
 #[inline(always)]
 pub fn open_path(path: *const c_char, flags: u32) -> SyscallResult<super::OwnedFd> {
     Sys::open(path as *const u8, flags as i32, 0)
-        .map(|fd| super::OwnedFd::from_raw(fd as RawFd))
+        // SAFETY: fd is a valid descriptor just returned by the kernel.
+        .map(|fd| unsafe { super::OwnedFd::from_raw(fd as RawFd) })
         .map_err(Into::into)
 }
 
@@ -166,7 +167,8 @@ pub fn list_dir(path: *const c_char, list: &mut UserFsList) -> SyscallResult<()>
 #[inline(always)]
 pub fn dup(fd: RawFd) -> SyscallResult<super::OwnedFd> {
     Sys::dup(fd)
-        .map(|v| super::OwnedFd::from_raw(v as RawFd))
+        // SAFETY: v is a valid fd just returned by the kernel.
+        .map(|v| unsafe { super::OwnedFd::from_raw(v as RawFd) })
         .map_err(Into::into)
 }
 
@@ -190,10 +192,13 @@ pub fn lseek(fd: RawFd, offset: i64, whence: u32) -> SyscallResult<i64> {
 pub fn pipe() -> SyscallResult<(super::OwnedFd, super::OwnedFd)> {
     let mut raw = [0i32; 2];
     Sys::pipe(&mut raw as *mut [i32; 2]).map_err(super::SyscallError::from)?;
-    Ok((
-        super::OwnedFd::from_raw(raw[0]),
-        super::OwnedFd::from_raw(raw[1]),
-    ))
+    // SAFETY: raw fds are valid descriptors just returned by the kernel.
+    Ok(unsafe {
+        (
+            super::OwnedFd::from_raw(raw[0]),
+            super::OwnedFd::from_raw(raw[1]),
+        )
+    })
 }
 
 /// Create a pipe pair with flags.  Returns `(read_end, write_end)` as `OwnedFd`.
@@ -202,10 +207,13 @@ pub fn pipe2(flags: u32) -> SyscallResult<(super::OwnedFd, super::OwnedFd)> {
     let mut raw = [0i32; 2];
     let result = unsafe { syscall2(SYSCALL_PIPE2, raw.as_mut_ptr() as u64, flags as u64) };
     demux(result)?;
-    Ok((
-        super::OwnedFd::from_raw(raw[0]),
-        super::OwnedFd::from_raw(raw[1]),
-    ))
+    // SAFETY: raw fds are valid descriptors just returned by the kernel.
+    Ok(unsafe {
+        (
+            super::OwnedFd::from_raw(raw[0]),
+            super::OwnedFd::from_raw(raw[1]),
+        )
+    })
 }
 
 #[inline(always)]
@@ -281,7 +289,8 @@ pub fn tiocsctty(fd: RawFd) -> SyscallResult<()> {
 #[inline(always)]
 pub fn ioctl_tiocgptpeer(master_fd: RawFd) -> SyscallResult<super::OwnedFd> {
     let result = unsafe { syscall3(SYSCALL_IOCTL, master_fd as u64, TIOCGPTPEER, 0) };
-    demux(result).map(|v| super::OwnedFd::from_raw(v as i32))
+    // SAFETY: v is a valid fd just returned by the kernel.
+    demux(result).map(|v| unsafe { super::OwnedFd::from_raw(v as i32) })
 }
 
 #[inline(always)]

--- a/userland/src/syscall/fs.rs
+++ b/userland/src/syscall/fs.rs
@@ -12,7 +12,7 @@ use super::RawFd;
 use super::error::{SyscallResult, demux};
 use super::numbers::*;
 use super::raw::{syscall1, syscall2, syscall3};
-use slopos_abi::syscall::{TIOCSCTTY, UserPollFd, UserTermios, UserTimeval};
+use slopos_abi::syscall::{TIOCGPTPEER, TIOCSCTTY, UserPollFd, UserTermios, UserTimeval};
 use slopos_abi::{UserFsList, UserFsStat};
 use slopos_slibc::pal::{Pal, Sys};
 
@@ -34,25 +34,32 @@ use slopos_slibc::pal::{Pal, Sys};
 /// * `EACCES` - Permission denied
 /// * `EINVAL` - Invalid flags
 #[inline(always)]
-pub fn open_path(path: *const c_char, flags: u32) -> SyscallResult<RawFd> {
+pub fn open_path(path: *const c_char, flags: u32) -> SyscallResult<super::OwnedFd> {
     Sys::open(path as *const u8, flags as i32, 0)
-        .map(|fd| fd as RawFd)
+        .map(|fd| super::OwnedFd::from_raw(fd as RawFd))
         .map_err(Into::into)
 }
 
 /// Open a file using a CStr path.
 #[inline(always)]
-pub fn open_cstr(path: &CStr, flags: u32) -> SyscallResult<RawFd> {
+pub fn open_cstr(path: &CStr, flags: u32) -> SyscallResult<super::OwnedFd> {
     open_path(path.as_ptr(), flags)
 }
 
-/// Close a file descriptor.
+/// Close a file descriptor by raw number.
 ///
-/// # Errors
-/// * `EBADF` - Invalid file descriptor
+/// Prefer dropping an `OwnedFd` instead.  This is the low-level escape
+/// hatch for closing well-known fds (0/1/2) or fds extracted via
+/// `OwnedFd::into_raw()`.
 #[inline(always)]
-pub fn close_fd(fd: RawFd) -> SyscallResult<()> {
+pub fn close_fd_raw(fd: RawFd) -> SyscallResult<()> {
     Sys::close(fd).map_err(Into::into)
+}
+
+/// Close an owned file descriptor.  Equivalent to `drop(fd)`.
+#[inline(always)]
+pub fn close_fd(fd: super::OwnedFd) {
+    drop(fd);
 }
 
 /// Read from a file descriptor into a buffer.
@@ -155,11 +162,17 @@ pub fn list_dir(path: *const c_char, list: &mut UserFsList) -> SyscallResult<()>
     demux(result).map(|_| ())
 }
 
+/// Duplicate a file descriptor, returning a new `OwnedFd`.
 #[inline(always)]
-pub fn dup(fd: RawFd) -> SyscallResult<RawFd> {
-    Sys::dup(fd).map(|v| v as RawFd).map_err(Into::into)
+pub fn dup(fd: RawFd) -> SyscallResult<super::OwnedFd> {
+    Sys::dup(fd)
+        .map(|v| super::OwnedFd::from_raw(v as RawFd))
+        .map_err(Into::into)
 }
 
+/// Duplicate `old_fd` onto `new_fd` (closing whatever was at `new_fd`).
+/// Returns the new fd number.  The `new_fd` slot is now a raw alias —
+/// its lifetime is NOT tracked by OwnedFd.
 #[inline(always)]
 pub fn dup2(old_fd: RawFd, new_fd: RawFd) -> SyscallResult<RawFd> {
     Sys::dup2(old_fd, new_fd)
@@ -172,15 +185,27 @@ pub fn lseek(fd: RawFd, offset: i64, whence: u32) -> SyscallResult<i64> {
     Sys::lseek(fd, offset, whence as i32).map_err(Into::into)
 }
 
+/// Create a pipe pair.  Returns `(read_end, write_end)` as `OwnedFd`.
 #[inline(always)]
-pub fn pipe(fds: &mut [i32; 2]) -> SyscallResult<()> {
-    Sys::pipe(fds as *mut [i32; 2]).map_err(Into::into)
+pub fn pipe() -> SyscallResult<(super::OwnedFd, super::OwnedFd)> {
+    let mut raw = [0i32; 2];
+    Sys::pipe(&mut raw as *mut [i32; 2]).map_err(super::SyscallError::from)?;
+    Ok((
+        super::OwnedFd::from_raw(raw[0]),
+        super::OwnedFd::from_raw(raw[1]),
+    ))
 }
 
+/// Create a pipe pair with flags.  Returns `(read_end, write_end)` as `OwnedFd`.
 #[inline(always)]
-pub fn pipe2(fds: &mut [i32; 2], flags: u32) -> SyscallResult<()> {
-    let result = unsafe { syscall2(SYSCALL_PIPE2, fds.as_mut_ptr() as u64, flags as u64) };
-    demux(result).map(|_| ())
+pub fn pipe2(flags: u32) -> SyscallResult<(super::OwnedFd, super::OwnedFd)> {
+    let mut raw = [0i32; 2];
+    let result = unsafe { syscall2(SYSCALL_PIPE2, raw.as_mut_ptr() as u64, flags as u64) };
+    demux(result)?;
+    Ok((
+        super::OwnedFd::from_raw(raw[0]),
+        super::OwnedFd::from_raw(raw[1]),
+    ))
 }
 
 #[inline(always)]
@@ -249,6 +274,14 @@ pub fn tcsetpgrp(fd: RawFd, pgid: u32) -> SyscallResult<()> {
 pub fn tiocsctty(fd: RawFd) -> SyscallResult<()> {
     let result = unsafe { syscall3(SYSCALL_IOCTL, fd as u64, TIOCSCTTY, 0) };
     demux(result).map(|_| ())
+}
+
+/// Open the PTY slave peer of a master FD (TIOCGPTPEER ioctl).
+/// Properly calls pty_open_slave in the kernel, incrementing open_count.
+#[inline(always)]
+pub fn ioctl_tiocgptpeer(master_fd: RawFd) -> SyscallResult<super::OwnedFd> {
+    let result = unsafe { syscall3(SYSCALL_IOCTL, master_fd as u64, TIOCGPTPEER, 0) };
+    demux(result).map(|v| super::OwnedFd::from_raw(v as i32))
 }
 
 #[inline(always)]

--- a/userland/src/syscall/fs.rs
+++ b/userland/src/syscall/fs.rs
@@ -57,10 +57,14 @@ pub fn close_fd_raw(fd: RawFd) -> SyscallResult<()> {
     Sys::close(fd).map_err(Into::into)
 }
 
-/// Close an owned file descriptor.  Equivalent to `drop(fd)`.
+/// Close an owned file descriptor, returning any kernel error.
+///
+/// Extracts the raw fd (preventing the `Drop` double-close), then
+/// performs the close syscall.  On failure the fd is already consumed
+/// — the kernel closed it or it was invalid.
 #[inline(always)]
-pub fn close_fd(fd: super::OwnedFd) {
-    drop(fd);
+pub fn close_fd(fd: super::OwnedFd) -> SyscallResult<()> {
+    close_fd_raw(fd.into_raw())
 }
 
 /// Read from a file descriptor into a buffer.

--- a/userland/src/syscall/mod.rs
+++ b/userland/src/syscall/mod.rs
@@ -76,7 +76,7 @@ impl OwnedFd {
     /// # Safety contract
     /// The caller must ensure `fd` is a valid, open file descriptor that
     /// is not owned by any other `OwnedFd`.
-    pub fn from_raw(fd: RawFd) -> Self {
+    pub unsafe fn from_raw(fd: RawFd) -> Self {
         Self(fd)
     }
 

--- a/userland/src/syscall/mod.rs
+++ b/userland/src/syscall/mod.rs
@@ -58,3 +58,46 @@ pub use wrappers::shm::{CachedShmMapping, ShmBuffer, ShmBufferRef};
 
 pub type UserWindowInfo = WindowInfo;
 pub type RawFd = i32;
+
+/// Owned file descriptor — closes automatically on drop.
+///
+/// This is the fd analog of `Box<T>`: it owns the resource and releases it
+/// when it goes out of scope.  NOT `Copy`, NOT `Clone` — you can't
+/// accidentally duplicate an fd or use one after close.
+///
+/// Use `.raw()` to borrow the fd number for syscalls that need `i32`.
+/// Use `.into_raw()` to take ownership without closing (e.g. after `dup2`
+/// to a well-known slot like stdin).
+pub struct OwnedFd(RawFd);
+
+impl OwnedFd {
+    /// Wrap a raw fd number into an owned handle.
+    ///
+    /// # Safety contract
+    /// The caller must ensure `fd` is a valid, open file descriptor that
+    /// is not owned by any other `OwnedFd`.
+    pub fn from_raw(fd: RawFd) -> Self {
+        Self(fd)
+    }
+
+    /// Borrow the raw fd number for passing to syscalls.
+    pub fn raw(&self) -> RawFd {
+        self.0
+    }
+
+    /// Consume the `OwnedFd` WITHOUT closing.  The caller takes
+    /// responsibility for the fd's lifetime.
+    pub fn into_raw(self) -> RawFd {
+        let fd = self.0;
+        std::mem::forget(self);
+        fd
+    }
+}
+
+impl Drop for OwnedFd {
+    fn drop(&mut self) {
+        if self.0 >= 0 {
+            let _ = super::syscall::fs::close_fd_raw(self.0);
+        }
+    }
+}

--- a/userland/src/syscall/mod.rs
+++ b/userland/src/syscall/mod.rs
@@ -97,7 +97,7 @@ impl OwnedFd {
 impl Drop for OwnedFd {
     fn drop(&mut self) {
         if self.0 >= 0 {
-            let _ = super::syscall::fs::close_fd_raw(self.0);
+            let _ = fs::close_fd_raw(self.0);
         }
     }
 }

--- a/userland/src/syscall/net.rs
+++ b/userland/src/syscall/net.rs
@@ -29,7 +29,8 @@ pub fn net_info(out: &mut UserNetInfo) -> i64 {
 
 pub fn socket(domain: u16, sock_type: u16, protocol: u16) -> SyscallResult<super::OwnedFd> {
     Sys::socket(domain as i32, sock_type as i32, protocol as i32)
-        .map(|v| super::OwnedFd::from_raw(v as i32))
+        // SAFETY: v is a valid fd just returned by the kernel.
+        .map(|v| unsafe { super::OwnedFd::from_raw(v as i32) })
         .map_err(Into::into)
 }
 
@@ -57,7 +58,8 @@ pub fn accept(fd: RawFd, peer: Option<&mut SockAddrIn>) -> SyscallResult<super::
         &mut addrlen as *mut u32
     };
     Sys::accept(fd, peer_ptr, addrlen_ptr)
-        .map(|v| super::OwnedFd::from_raw(v as i32))
+        // SAFETY: v is a valid fd just returned by the kernel.
+        .map(|v| unsafe { super::OwnedFd::from_raw(v as i32) })
         .map_err(Into::into)
 }
 

--- a/userland/src/syscall/net.rs
+++ b/userland/src/syscall/net.rs
@@ -27,9 +27,9 @@ pub fn net_info(out: &mut UserNetInfo) -> i64 {
     unsafe { syscall1(SYSCALL_NET_INFO, out as *mut UserNetInfo as u64) as i64 }
 }
 
-pub fn socket(domain: u16, sock_type: u16, protocol: u16) -> SyscallResult<RawFd> {
+pub fn socket(domain: u16, sock_type: u16, protocol: u16) -> SyscallResult<super::OwnedFd> {
     Sys::socket(domain as i32, sock_type as i32, protocol as i32)
-        .map(|v| v as RawFd)
+        .map(|v| super::OwnedFd::from_raw(v as i32))
         .map_err(Into::into)
 }
 
@@ -46,7 +46,7 @@ pub fn listen(fd: RawFd, backlog: u32) -> SyscallResult<()> {
     Sys::listen(fd, backlog as i32).map_err(Into::into)
 }
 
-pub fn accept(fd: RawFd, peer: Option<&mut SockAddrIn>) -> SyscallResult<RawFd> {
+pub fn accept(fd: RawFd, peer: Option<&mut SockAddrIn>) -> SyscallResult<super::OwnedFd> {
     let mut addrlen = core::mem::size_of::<SockAddrIn>() as u32;
     let peer_ptr = peer
         .map(|p| p as *mut _ as *mut u8)
@@ -57,7 +57,7 @@ pub fn accept(fd: RawFd, peer: Option<&mut SockAddrIn>) -> SyscallResult<RawFd> 
         &mut addrlen as *mut u32
     };
     Sys::accept(fd, peer_ptr, addrlen_ptr)
-        .map(|v| v as RawFd)
+        .map(|v| super::OwnedFd::from_raw(v as i32))
         .map_err(Into::into)
 }
 

--- a/userland/src/syscall/process.rs
+++ b/userland/src/syscall/process.rs
@@ -3,6 +3,17 @@
 use super::numbers::*;
 use super::raw::{syscall0, syscall1, syscall2, syscall3, syscall4, syscall6};
 use slopos_abi::signal::{SIG_IGN, SigSet, UserSigaction};
+
+/// Signal restorer trampoline — called when a signal handler returns.
+///
+/// The restorer address is pushed as a separate stack word before the
+/// `SignalFrame`.  After the handler's `ret` pops the restorer, RSP points
+/// directly at the `SignalFrame`, so `rt_sigreturn` (syscall 105) reads
+/// the frame from the correct address — no stack adjustment needed.
+#[unsafe(naked)]
+extern "C" fn signal_restorer() {
+    core::arch::naked_asm!("mov eax, 105", "syscall", "ud2");
+}
 use slopos_slibc::pal::{Pal, Sys};
 
 #[inline(always)]
@@ -81,6 +92,17 @@ pub fn openpty() -> Result<(u32, u32), i64> {
         Err(ret)
     } else {
         Ok((master, slave))
+    }
+}
+
+/// Open a file descriptor for a TTY by its kernel index.
+#[inline(always)]
+pub fn open_tty_fd(tty_idx: u32) -> Result<super::OwnedFd, i64> {
+    let ret = unsafe { syscall1(SYSCALL_OPEN_TTY_FD, tty_idx as u64) as i64 };
+    if ret < 0 {
+        Err(ret)
+    } else {
+        Ok(super::OwnedFd::from_raw(ret as i32))
     }
 }
 
@@ -174,6 +196,31 @@ pub fn ignore_signal(signum: u8) -> i32 {
         sa_handler: SIG_IGN,
         sa_flags: 0,
         sa_restorer: 0,
+        sa_mask: 0,
+    };
+    unsafe {
+        syscall4(
+            SYSCALL_RT_SIGACTION,
+            signum as u64,
+            (&action as *const UserSigaction) as u64,
+            0,
+            core::mem::size_of::<SigSet>() as u64,
+        ) as i32
+    }
+}
+
+/// Install a custom signal handler with proper restorer trampoline.
+///
+/// The handler receives the signal number as its argument.  When it returns,
+/// the restorer automatically invokes `rt_sigreturn` to resume the
+/// interrupted context.  `SA_RESTART` is deliberately omitted so that
+/// blocking syscalls (e.g. `poll`) return early after the handler runs.
+#[inline(always)]
+pub fn set_signal_handler(signum: u8, handler: extern "C" fn(i32)) -> i32 {
+    let action = UserSigaction {
+        sa_handler: handler as *const () as u64,
+        sa_flags: 0,
+        sa_restorer: signal_restorer as *const () as u64,
         sa_mask: 0,
     };
     unsafe {

--- a/userland/src/syscall/process.rs
+++ b/userland/src/syscall/process.rs
@@ -102,7 +102,8 @@ pub fn open_tty_fd(tty_idx: u32) -> Result<super::OwnedFd, i64> {
     if ret < 0 {
         Err(ret)
     } else {
-        Ok(super::OwnedFd::from_raw(ret as i32))
+        // SAFETY: ret is a valid fd just returned by the kernel.
+        Ok(unsafe { super::OwnedFd::from_raw(ret as i32) })
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer owned-FD wrapper and explicit TTY-open syscall; shell now forwards keyboard into the PTY master for improved interactivity.

* **Bug Fixes**
  * Fixed signal-handler stack layout so the restorer value is placed and invoked reliably.

* **Improvements**
  * Typed open-mode handling for file operations and consistent use of raw descriptors across networking and CLI tools.
  * Cleaner signal delivery/restore behavior.

* **Tests**
  * Scheduler tests now reset per-CPU inbox counts and fail fast on init errors to avoid cross-test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->