### PR TITLE
test: harden QEMU/test harness timeouts and make init test fast-path deterministic

### DIFF
--- a/core/src/syscall/test_handlers.rs
+++ b/core/src/syscall/test_handlers.rs
@@ -64,6 +64,7 @@ define_syscall!(syscall_test_report
 
 define_syscall!(syscall_run_userland_tests (ctx) -> Result<(), Errno> {
     if !kernel_phase_summary::tests_enabled() {
+        klog_info!("TESTS: run_userland_tests ignored; kernel phase not enabled");
         return Ok(());
     }
 

--- a/justfile
+++ b/justfile
@@ -49,6 +49,9 @@ qemu_gtk_zoom       := env("QEMU_GTK_ZOOM_TO_FIT", "off")
 boot_log_timeout := env("BOOT_LOG_TIMEOUT", "15")
 boot_cmdline     := env("BOOT_CMDLINE", "tests=off")
 test_cmdline     := "tests=on tests.shutdown=on tests.verbosity=summary boot.debug=on roulette=skip"
+test_timeout_secs := env("TEST_TIMEOUT_SECS", "900")
+test_silence_secs := env("TEST_SILENCE_SECS", "120")
+test_harness_args := "--timeout-secs " + test_timeout_secs + " --silence-secs " + test_silence_secs
 # `TEST_CMDLINE=…` env override lets `builddir/run_tests` thread filter
 # / verbosity flags into the ISO at build time. Mirrors `BOOT_CMDLINE` for
 # the non-test path.
@@ -262,31 +265,31 @@ _build-run-tests:
 
 [doc("Run the SlopOS test harness — live progress bar, per-failure detail, FILTER='glob' supported")]
 test FILTER='': _build-run-tests
-    {{build_dir}}/run_tests --filter "{{FILTER}}"
+    {{build_dir}}/run_tests {{test_harness_args}} --filter "{{FILTER}}"
 
 [doc("Re-run only the tests that failed on the previous `just test` invocation.")]
 test-rerun-failed: _build-run-tests
-    {{build_dir}}/run_tests --rerun-failed
+    {{build_dir}}/run_tests {{test_harness_args}} --rerun-failed
 
 [doc("Same as `just test` but dump captured klog of every test (not only failures).")]
 test-verbose FILTER='': _build-run-tests
-    {{build_dir}}/run_tests --verbose --filter "{{FILTER}}"
+    {{build_dir}}/run_tests {{test_harness_args}} --verbose --filter "{{FILTER}}"
 
 [doc("Suppress per-test output; render only failures + summary.")]
 test-quiet FILTER='': _build-run-tests
-    {{build_dir}}/run_tests --quiet --filter "{{FILTER}}"
+    {{build_dir}}/run_tests {{test_harness_args}} --quiet --filter "{{FILTER}}"
 
 [doc("Passthrough QEMU stdout verbatim — KTAP and klog interleaved. Last-resort debugging.")]
 test-raw: _build-run-tests
-    {{build_dir}}/run_tests --raw
+    {{build_dir}}/run_tests {{test_harness_args}} --raw
 
 [doc("Append one JSON event per line to PATH (machine-consumable).")]
 test-json PATH: _build-run-tests
-    {{build_dir}}/run_tests --json "{{PATH}}"
+    {{build_dir}}/run_tests {{test_harness_args}} --json "{{PATH}}"
 
 [doc("Skip the kernel-side test phase; run only the Phase 3 userland tests.")]
 test-userland-only: _iso-tests-userland-only _build-run-tests
-    {{build_dir}}/run_tests --no-build --iso "{{iso_tests}}" --fs-image "{{fs_image_tests}}"
+    {{build_dir}}/run_tests {{test_harness_args}} --no-build --iso "{{iso_tests}}" --fs-image "{{fs_image_tests}}"
 
 [doc("Run host-side unit tests: abi, gfx, font, plus the slopos-ostd suite natively (same tests KernMiri interprets, seconds instead of minutes — catches assertion drift early; UB detection still needs `just check-miri`)")]
 test-host:

--- a/scripts/qemu_run.sh
+++ b/scripts/qemu_run.sh
@@ -95,6 +95,7 @@ OVMF_VARS="${OVMF_DIR}/OVMF_VARS.fd"
 BOOT_LOG_TIMEOUT="${BOOT_LOG_TIMEOUT:-15}"
 LOG_FILE="${LOG_FILE:-test_output.log}"
 LOG_FILE_RAW="${LOG_FILE}.raw"
+SCRATCH_CLEANUP=""
 
 # ── Validate SMP ─────────────────────────────────────────────────────────────
 if [ "$QEMU_SMP" -lt 1 ]; then
@@ -117,7 +118,7 @@ fi
 
 # ── Create runtime OVMF_VARS copy ────────────────────────────────────────────
 OVMF_VARS_RUNTIME="$(mktemp "${OVMF_DIR}/OVMF_VARS.runtime.XXXXXX.fd")"
-cleanup() { rm -f "$OVMF_VARS_RUNTIME"; }
+cleanup() { rm -f "$OVMF_VARS_RUNTIME" ${SCRATCH_CLEANUP:+"$SCRATCH_CLEANUP"}; }
 trap cleanup EXIT INT TERM
 cp "$OVMF_VARS" "$OVMF_VARS_RUNTIME"
 
@@ -171,10 +172,17 @@ case "$MODE" in
         # backend is wired to COM1.
         DISPLAY_ARGS=(-display none)
         EXTRA_ARGS=(-device "isa-debug-exit,iobase=0xf4,iosize=0x01" -no-reboot)
-        SCRATCH_IMG="${SCRATCH_IMG:-${REPO_ROOT}/builddir/scratch-disk.img}"
-        mkdir -p "$(dirname "$SCRATCH_IMG")"
+        if [ -n "${SCRATCH_IMG:-}" ]; then
+            mkdir -p "$(dirname "$SCRATCH_IMG")"
+            # Explicit debugging override: keep the historical path contract,
+            # but still start each run from a fresh raw disk.
+            rm -f "$SCRATCH_IMG"
+        else
+            mkdir -p "${REPO_ROOT}/builddir"
+            SCRATCH_IMG="$(mktemp "${REPO_ROOT}/builddir/scratch-disk.XXXXXX.img")"
+            SCRATCH_CLEANUP="$SCRATCH_IMG"
+        fi
         # Fresh, blank 8 MiB raw scratch each run (no filesystem; raw-sector tests only).
-        rm -f "$SCRATCH_IMG"
         truncate -s 8M "$SCRATCH_IMG"
         SCRATCH_ARGS=(
             -drive "file=$SCRATCH_IMG,if=none,id=virtio-disk1,format=raw"
@@ -313,8 +321,8 @@ case "$MODE" in
         sleep 0.2
         kill "$tail_pid" 2>/dev/null
         wait "$tail_pid" 2>/dev/null || true
+        cleanup
         trap - EXIT INT TERM
-        rm -f "$OVMF_VARS_RUNTIME"
 
         sed 's/\x1b\[[^a-zA-Z]*[a-zA-Z]//g' "$LOG_FILE_RAW" > "$LOG_FILE"
         rm -f "$LOG_FILE_RAW"
@@ -331,8 +339,8 @@ case "$MODE" in
         "$QEMU_BIN" "${QEMU_ARGS[@]}"
         status=$?
         set -e
+        cleanup
         trap - EXIT INT TERM
-        rm -f "$OVMF_VARS_RUNTIME"
         if [ $status -eq 1 ]; then
             echo "Tests passed."
         elif [ $status -eq 3 ]; then

--- a/tools/run_tests/cmdline.go
+++ b/tools/run_tests/cmdline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -94,8 +95,8 @@ func parseArgs(argv []string) (*Args, error) {
 	fs := flag.NewFlagSet("run_tests", flag.ContinueOnError)
 	a := &Args{
 		ColorMode:   "auto",
-		TimeoutSecs: 900,
-		SilenceSecs: 120,
+		TimeoutSecs: envIntDefault("RUN_TESTS_TIMEOUT_SECS", 900),
+		SilenceSecs: envIntDefault("RUN_TESTS_SILENCE_SECS", 120),
 		WarnMs:      500,
 	}
 	var filters, skips stringSlice
@@ -108,8 +109,8 @@ func parseArgs(argv []string) (*Args, error) {
 	fs.StringVar(&a.JsonPath, "json", "", "Append one JSON event per line to PATH.")
 	fs.StringVar(&a.ColorMode, "color", "auto", "Colour mode: auto|always|never.")
 	fs.BoolVar(&a.NoColor, "no-color", false, "Alias for --color=never.")
-	fs.IntVar(&a.TimeoutSecs, "timeout-secs", 900, "Wall-clock guard for the whole run; 0 disables.")
-	fs.IntVar(&a.SilenceSecs, "silence-secs", 120, "Abort if QEMU stdout is silent for this long; 0 disables.")
+	fs.IntVar(&a.TimeoutSecs, "timeout-secs", a.TimeoutSecs, "Wall-clock guard for the whole run; 0 disables. Defaults to RUN_TESTS_TIMEOUT_SECS or 900.")
+	fs.IntVar(&a.SilenceSecs, "silence-secs", a.SilenceSecs, "Abort if QEMU stdout is silent for this long; 0 disables. Defaults to RUN_TESTS_SILENCE_SECS or 120.")
 	fs.IntVar(&a.WarnMs, "warn-ms", 500, "Mark tests slower than this as OVER_TIME.")
 	fs.StringVar(&a.Iso, "iso", "", "Test ISO path.")
 	fs.StringVar(&a.FsImage, "fs-image", "", "Test fs image path.")
@@ -177,4 +178,16 @@ func assembleTestCmdline(base string, filters, skips []string, verbosity, extra 
 		parts = append(parts, extra)
 	}
 	return strings.Join(parts, " ")
+}
+
+func envIntDefault(name string, fallback int) int {
+	raw, ok := os.LookupEnv(name)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return fallback
+	}
+	return value
 }

--- a/tools/run_tests/driver.go
+++ b/tools/run_tests/driver.go
@@ -91,9 +91,9 @@ func (d *QemuDriver) Run(ctx context.Context, onLine func(string)) (DriverResult
 	waitCh := make(chan error, 1)
 	go func() { waitCh <- cmd.Wait() }()
 
-	// Silence watchdog. lastLine is the monotonic time of the last byte
-	// received from QEMU. Watcher goroutine polls it and trips when the
-	// pipe goes dead longer than SilenceSec.
+	// Silence watchdog. lastLine is the monotonic time of the last complete
+	// line received from QEMU. Watcher goroutine polls it and trips when
+	// the parsed line stream goes dead longer than SilenceSec.
 	var lastLine atomic.Int64
 	lastLine.Store(time.Now().UnixNano())
 	silenceCtx, silenceCancel := context.WithCancel(context.Background())

--- a/tools/run_tests/main.go
+++ b/tools/run_tests/main.go
@@ -207,7 +207,7 @@ func run(rawArgv []string) int {
 	// Snapshot the parser's klog ring buffer when the run aborted —
 	// without it, summary-verbosity CI failures show a "TIMED OUT"
 	// banner with no kernel context.
-	if driverRes.TimedOut || driverRes.UserAborted || recorder.Summary.Truncated {
+	if driverRes.TimedOut || driverRes.UserAborted || recorder.Summary.Truncated || recorder.Summary.HarnessError != nil {
 		recorder.Summary.AbortKlogTail = parser.KlogTail()
 	}
 
@@ -222,7 +222,7 @@ func run(rawArgv []string) int {
 			break
 		}
 	}
-	failedOverall := len(failures) > 0 || bailed || driverRes.TimedOut || recorder.Summary.Truncated
+	failedOverall := len(failures) > 0 || bailed || driverRes.TimedOut || recorder.Summary.Truncated || recorder.Summary.HarnessError != nil
 
 	exitCode := 0
 	switch {

--- a/tools/run_tests/recorder.go
+++ b/tools/run_tests/recorder.go
@@ -83,6 +83,7 @@ type RunSummary struct {
 	TimedOut          bool
 	SilenceHit        bool
 	QemuStatus        *int
+	HarnessError      *string
 	// AbortKlogTail is the parser's rolling window of recent non-KTAP
 	// klog lines, snapshotted at finalize time when the run aborted
 	// (timeout / silence / truncation). Populated by main; rendered by
@@ -235,6 +236,10 @@ func (r *RunRecorder) Record(ev Event) {
 func (r *RunRecorder) Finalize(qemuStatus *int) {
 	r.Summary.FinishedMonotonic = time.Now()
 	r.Summary.QemuStatus = qemuStatus
+	if len(r.Summary.Phases) == 0 {
+		reason := "NO KTAP output: QEMU exited before the kernel test harness announced a phase"
+		r.Summary.HarnessError = &reason
+	}
 	for _, p := range r.Summary.Phases {
 		observed := len(p.Tests)
 		if p.PlanN != nil && observed < *p.PlanN && p.BailReason == nil {

--- a/tools/run_tests/renderer_bar.go
+++ b/tools/run_tests/renderer_bar.go
@@ -465,7 +465,7 @@ func (r *BarRenderer) renderSummary(summary *RunSummary) {
 	// "TIMED OUT" banner. With summary verbosity (the CI default) klog
 	// is otherwise suppressed entirely, leaving us blind to where the
 	// kernel was when it wedged.
-	if (summary.TimedOut || summary.UserAborted || summary.Truncated) &&
+	if (summary.TimedOut || summary.UserAborted || summary.Truncated || summary.HarnessError != nil) &&
 		len(summary.AbortKlogTail) > 0 {
 		r.println(Paint(
 			fmt.Sprintf("klog tail (last %d non-KTAP lines before abort):",
@@ -528,6 +528,8 @@ func (r *BarRenderer) renderSummary(summary *RunSummary) {
 				total, nPhases, plural, passed, failed, skipped, overTime),
 			ansiYellow, r.Colour,
 		))
+	case summary.HarnessError != nil:
+		r.println(Paint(*summary.HarnessError, ansiRedBold, r.Colour))
 	case failed == 0 && !summary.Truncated:
 		r.println(Paint(
 			fmt.Sprintf("%d tests across %d phase%s  →  "+

--- a/tools/run_tests/renderer_test.go
+++ b/tools/run_tests/renderer_test.go
@@ -61,6 +61,24 @@ func TestRendererTimeoutDumpsKlogTail(t *testing.T) {
 	}
 }
 
+func TestRendererNoKtapRunIsHarnessError(t *testing.T) {
+	rec := NewRecorder()
+	status := 0
+	rec.Finalize(&status)
+
+	if rec.Summary.HarnessError == nil {
+		t.Fatalf("expected harness error for run with no KTAP phases")
+	}
+
+	var buf bytes.Buffer
+	r := NewBarRenderer(&buf, "summary", false, 0, false, 100)
+	r.Finalize(rec.Summary)
+	out := buf.String()
+	if !strings.Contains(out, "NO KTAP output") {
+		t.Errorf("missing no-KTAP diagnostic: %q", out)
+	}
+}
+
 // Smoke test: green run renders summary line, no failure block.
 func TestRendererGreenRunSummary(t *testing.T) {
 	lines := []string{

--- a/userland/src/apps/init_process.rs
+++ b/userland/src/apps/init_process.rs
@@ -40,8 +40,6 @@ fn spawn_service(name: &str) -> i32 {
 }
 
 pub fn init_user_main() {
-    upgrade_console_font();
-
     let mut info = UserSysInfo::default();
     let info_ok = sys_core::sys_info(&mut info) == 0;
     let skip_roulette = info_ok && (info.boot_flags & BOOT_FLAG_ROULETTE_SKIP) != 0;
@@ -49,7 +47,11 @@ pub fn init_user_main() {
 
     if tests_enabled {
         // Drive the kernel-side userland-test phase from this task's
-        // context. The syscall handler walks the `.test_registry`,
+        // context before doing any interactive-session setup. Font atlas
+        // loading/rasterization is useful for a real desktop boot, but it
+        // is pure overhead for `just test` and can leave the host harness
+        // silent long enough to trip short CI watchdogs on slower QEMU
+        // backends. The syscall handler walks the `.test_registry`,
         // spawns each utest binary, blocks on its exit via
         // `task_wait_for`, drains its `SYSCALL_TEST_REPORT` ring, emits
         // KTAP, merges with the kernel-phase summary, and triggers the
@@ -62,6 +64,8 @@ pub fn init_user_main() {
             sys_core::exit_with_code(0);
         }
     }
+
+    upgrade_console_font();
 
     if !skip_roulette {
         let roulette_tid = spawn_service("roulette");


### PR DESCRIPTION
### Motivation

- Flakiness in `just test` stems from an unexposed harness timeout surface, shared scratch disk races, and a boot handoff that can delay the userland test phase long enough to trip host-side watchdogs under slow (TCG) runners.  

### Description

- Expose harness timeout & silence knobs through `just test` recipes via `TEST_TIMEOUT_SECS` / `TEST_SILENCE_SECS` and thread them into the `builddir/run_tests` invocation.  
- Make `tools/run_tests` read defaults from `RUN_TESTS_TIMEOUT_SECS` / `RUN_TESTS_SILENCE_SECS`, accept the CLI flags as final override, and surface zero-KTAP runs as a `HarnessError` (fail + render klog tail).  
- Improve renderer/recorder to detect and render no-KTAP / harness-error cases and include a unit test for the new diagnostic.  
- Make QEMU test-mode use a unique per-run scratch image (via `mktemp`) and clean it up with the OVMF runtime vars to avoid concurrent-run collisions.  
- Move `/sbin/init`’s userland-test fast-path ahead of desktop/font initialization so `SYSCALL_RUN_USERLAND_TESTS` runs promptly in test boots; also log when the syscall is ignored because the kernel-phase flag is not set.  
- Clarify the silence-watchdog comment (line-based activity) and minor tooling/ci plumbing changes (`justfile`, `scripts/qemu_run.sh`, `tools/run_tests/*`).

### Testing

- `cd tools/run_tests && go test ./...` — passed.  
- `just check-tests-host` — passed.  
- `cargo fmt --all` — passed.  
- `TEST_TIMEOUT_SECS=25 TEST_SILENCE_SECS=25 just test` — exercised the new `just` plumbing and confirmed the 25s timeouts are forwarded into the harness; in this environment (no /dev/kvm) the run times out as expected under TCG, and the harness now emits klog-tail diagnostics.  
- `builddir/run_tests --timeout-secs 150 --silence-secs 60 --no-color` and larger timeouts — verified the change let the run progress past the prior pre-userland hang (now reaches `TESTS: Running userland phase (init syscall)`), but slow TCG execution still requires larger timeouts in this container (behaviour consistent with no-KVM environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28ef00be108329a7d1a31c3e3edefd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when kernel test harness fails to initialize.
  * Enhanced cleanup of temporary disk images used during testing.

* **Chores**
  * Made test timeouts configurable via environment variables.
  * Optimized test execution by deferring non-essential setup during test runs, reducing test duration.
  * Enhanced test logging for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->